### PR TITLE
Ledger signmessage/getxpub support, command cleanup

### DIFF
--- a/hwi.py
+++ b/hwi.py
@@ -129,7 +129,7 @@ def process_commands(command, command_args, device_path, device_type):
     if command == 'getmasterxpub':
         print(client.get_master_xpub())
 
-    if command == 'signtx':
+    elif command == 'signtx':
         # Deserialize the transaction
         try:
             tx = PSBT()
@@ -141,11 +141,12 @@ def process_commands(command, command_args, device_path, device_type):
             print(json.dumps({'error':'You must provide a PSBT','code':INVALID_TX}))
             exit
 
-    if command == 'getxpub':
+    elif command == 'getxpub':
         print(client.get_pubkey_at_path(command_args[0]))
-
-    if command == 'signmessage':
+    elif command == 'signmessage':
         print(client.sign_message(command_args[0], command_args[1]))
+    else:
+        print(json.dumps({'error':'Unknown command'}))
 
     # Close the device
     device.close()

--- a/hwi.py
+++ b/hwi.py
@@ -115,6 +115,8 @@ def process_commands(command, command_args, device_path, device_type):
         import keepkeyi
         client = keepkeyi.KeepKeyClient(device=device, path=device_path)
     elif device_type == 'ledger':
+        # hack to use btchip-python's getDongle pipeline
+        device.close()
         import ledgeri
         client = ledgeri.LedgerClient(device=device)
     elif device_type == 'digitalbitbox':

--- a/ledgeri.py
+++ b/ledgeri.py
@@ -55,7 +55,6 @@ class LedgerClient(HardwareWalletClient):
         depth = struct.pack("B", depth)
 
         version = "0488B21E".decode('hex')
-        version = "043587cf".decode('hex')
         extkey = version+depth+fpr+child+chainCode+publicKey
         checksum = hash256(extkey)[:4]
 

--- a/ledgeri.py
+++ b/ledgeri.py
@@ -1,13 +1,20 @@
 # Ledger interaction script
 
 from hwi import HardwareWalletClient
+from btchip.btchip import *
+from btchip.btchipUtils import *
+import base64
+import json
 
-# This class extends the HardwareWalletClient for Digital Bitbox specific things
+# This class extends the HardwareWalletClient for Ledger Nano S specific things
 class LedgerClient(HardwareWalletClient):
 
     # device is an HID device that has already been opened.
+    # hacked in device support using btchip-python
     def __init__(self, device):
         super(LedgerClient, self).__init__(device)
+        dongle = getDongle(True)
+        self.app = btchip(dongle)
         self.device = device
 
     # Must return a dict with the pubkey, chaincode, and xpub. The pubkey and
@@ -25,19 +32,36 @@ class LedgerClient(HardwareWalletClient):
 
     # Must return a base64 encoded string with the signed message
     # The message can be any string
-    def sign_message(self, message):
-        raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+    def sign_message(self, message, keypath):
+        keypath = keypath[2:]
+        # First display on screen what address you're signing for
+        self.app.getWalletPublicKey(keypath, True)
+        self.app.signMessagePrepare(keypath, message)
+        signature = self.app.signMessageSign()
+
+        # Make signature into standard bitcoin format
+        rLength = signature[3]
+        r = signature[4 : 4 + rLength]
+        sLength = signature[4 + rLength + 1]
+        s = signature[4 + rLength + 2:]
+        if rLength == 33:
+            r = r[1:]
+        if sLength == 33:
+            s = s[1:]
+        r = str(r)
+        s = str(s)
+
+        sig = chr(27 + 4 + (signature[0] & 0x01)) + r + s
+
+        return json.dumps({"signature":base64.b64encode(sig)})
 
     # Setup a new device
     def setup_device(self):
-        raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+        raise NotImplementedError('The Ledger Nano S does not support software setup')
 
     # Wipe this device
     def wipe_device(self):
-        raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+        raise NotImplementedError('The Ledger Nano S does not support wiping via software')
 
 # Avoid circular imports
 from hwi import HardwareWalletClient

--- a/serializations.py
+++ b/serializations.py
@@ -538,10 +538,11 @@ class PSBT(object):
             value_len = deser_compact_size(f)
 
             # Do stuff based on type
-            # Raw tx or non witness utxo
             if key_type == 0x00:
+                # Raw tx
                 if in_globals:
                     self.tx.deserialize(f)
+                # Non-witness utxo
                 else:
                     # Read in the transaction
                     tx = CTransaction()
@@ -553,8 +554,8 @@ class PSBT(object):
                         raise IOError("Provided non witness utxo does not match the required utxo for input")
 
                     psbt_input.non_witness_utxo = tx
-            # redeemscript or witness utxo
             elif key_type == 0x01:
+                # redeemscript
                 if in_globals:
                     # retrieve hash160 from key
                     script_hash160 = key[1:]
@@ -569,6 +570,7 @@ class PSBT(object):
 
                     # add to map
                     self.redeem_scripts[script_hash160] = redeemscript
+                # witness utxo
                 else:
                     # read in the utxo
                     vout = CTxOut()
@@ -576,8 +578,8 @@ class PSBT(object):
 
                     # add to map
                     psbt_input.witness_utxo = vout
-            # witness script
             elif key_type == 0x02:
+                # witness script
                 if in_globals:
                     # retrieve sha256 from key
                     script_sha256 = key[1:]
@@ -592,6 +594,7 @@ class PSBT(object):
 
                     # add to map
                     self.witness_scripts[script_sha256] = witnessscript
+                # partial signature
                 else:
                     # read in the pubkey from key
                     pubkey = key[1:]


### PR DESCRIPTION
Has an ugly hack(closing the device and re-opening again later), but allows me to use the btchip-python `getDongle` flow and other calls natively.

Hopefully could clean that up with more inspection of the btchip-python code and pulling out the necessary parts.