### PR TITLE
Support non-segwit signing IFF there are no segwit inputs

### DIFF
--- a/ledgeri.py
+++ b/ledgeri.py
@@ -129,7 +129,7 @@ class LedgerClient(HardwareWalletClient):
             if psbt_in.witness_utxo is not None and psbt_in.witness_utxo.is_p2sh():
                 redeemscript = psbt_in.redeem_script
                 witness_program += redeemscript
-            elif psbt_in.witness_utxo is not None and psbt_in.non_witness_utxo.is_p2sh():
+            elif psbt_in.non_witness_utxo is not None and psbt_in.non_witness_utxo.vout[txin.prevout.n].is_p2sh():
                 redeemscript = psbt_in.redeem_script
             elif psbt_in.witness_utxo is not None:
                 witness_program += psbt_in.witness_utxo.scriptPubKey


### PR DESCRIPTION
Due to Ledger's signing firmware, it can only sign non-segwit
spending transactions when it receives the full previous transaction.
Therefore we just support signing:
1) Segwit inputs in a transaction with segwit inputs
2) Legacy inputs in a non-segwit-spending transaction

Manually tested:
1) Segwit only
2) Mixed, where it will only sign segwit inputs
3) legacy only

But this needs more review/testing to at least make sure I didn't break segwit-only cases.