### PR TITLE
Updates and fixes to getkeypool and keypaths

### DIFF
--- a/base58.py
+++ b/base58.py
@@ -71,10 +71,10 @@ def get_xpub_fingerprint(s):
     fingerprint = data[5:9]
     return struct.unpack("<I", fingerprint)[0]
 
-def get_xpub_id(xpub):
+def get_xpub_fingerprint_as_id(xpub):
     data = decode(xpub)
-    pubkey = data[-37:-4]
-    return hexlify(hash160(pubkey)[::-1]).decode()
+    fingerprint = data[5:9] + b'\x00' * 16
+    return hexlify(fingerprint[::-1]).decode()
 
 def to_address(b, version):
     data = version + b

--- a/base58.py
+++ b/base58.py
@@ -82,13 +82,22 @@ def to_address(b, version):
     data += checksum
     return encode(data)
 
-def xpub_to_address(xpub):
+def xpub_to_address(xpub, testnet=False):
     data = decode(xpub)
     pubkey = data[-37:-4]
     pkh = hash160(pubkey)
-    return to_address(pkh, b'\x00')
+    if testnet:
+        return to_address(pkh, b'\x6f')
+    else:
+        return to_address(pkh, b'\x00')
 
 def xpub_to_pub_hex(xpub):
     data = decode(xpub)
     pubkey = data[-37:-4]
     return hexlify(pubkey).decode()
+
+def xpub_main_2_test(xpub):
+    data = decode(xpub)
+    test_data = b'\x04\x35\x87\xCF' + data[4:-4]
+    checksum = hash256(test_data)[0:4]
+    return encode(test_data + checksum)

--- a/digitalbitboxi.py
+++ b/digitalbitboxi.py
@@ -11,7 +11,7 @@ import binascii
 
 from hwi import HardwareWalletClient
 from serializations import CTransaction, PSBT, hash256, hash160, ser_sig_der, ser_sig_compact, ser_compact_size
-from base58 import get_xpub_fingerprint, decode, to_address
+from base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test
 
 applen = 225280 # flash size minus bootloader length
 chunksize = 8*512
@@ -153,7 +153,11 @@ class DigitalBitboxClient(HardwareWalletClient):
         reply = send_encrypt('{"xpub":"' + path + '"}', self.password, self.device)
         if 'error' in reply:
             return reply
-        return json.dumps({'xpub':reply['xpub']})
+
+        if self.is_testnet:
+            return json.dumps({'xpub':xpub_main_2_test(reply['xpub'])})
+        else:
+            return json.dumps({'xpub':reply['xpub']})
 
     # Must return a hex string with the signed transaction
     # The tx must be in the PSBT format

--- a/hwi.py
+++ b/hwi.py
@@ -187,6 +187,10 @@ def process_commands():
         path_base = command_args[0]
         start = int(command_args[1])
         end = int(command_args[2])
+
+        if device_type == 'digitalbitbox':
+            if '\'' not in path_base and 'h' not in path_base and 'H' not in path_base:
+                print(json.dumps({'error' : 'The digital bitbox requires one part of the derivation path to be derived using hardened keys'}))
         master_xpub = json.loads(client.get_pubkey_at_path('m/0h'))['xpub']
         master_fpr = get_xpub_fingerprint_as_id(master_xpub)
 

--- a/hwi.py
+++ b/hwi.py
@@ -27,6 +27,7 @@ class HardwareWalletClient(object):
     def __init__(self, device):
         self.device = device
         self.message_magic = b"\x18Bitcoin Signed Message:\n"
+        self.is_testnet = False
 
     # Get the master BIP 44 pubkey
     def get_master_xpub(self):
@@ -89,6 +90,7 @@ def process_commands():
     parser.add_argument('--device-path', '-d', help='Specify the device path of the device to connect to')
     parser.add_argument('--device-type', '-t', help='Specify the type of device that will be connected')
     parser.add_argument('--password', '-p', help='Device password if it has one (e.g. DigitalBitbox)')
+    parser.add_argument('--testnet', help='Use testnet prefixes', action='store_true')
     parser.add_argument('command', help='The action to do')
     parser.add_argument('args', help='Arguments for the command', nargs='*')
 
@@ -155,7 +157,8 @@ def process_commands():
     else:
         result = {'error':'Unknown device type specified','code':UNKNWON_DEVICE_TYPE}
         print(json.dumps(result))
-        exit
+        return
+    client.is_testnet = args.testnet
 
     # Do the commands
     if command == 'getmasterxpub':
@@ -195,7 +198,7 @@ def process_commands():
             else:
                 path = path_base + '/' + str(i)
             xpub = json.loads(client.get_pubkey_at_path(path))['xpub']
-            address = xpub_to_address(xpub)
+            address = xpub_to_address(xpub, args.testnet)
             this_import['scriptPubKey'] = {'address' : address}
             this_import['pubkeys'] = [{xpub_to_pub_hex(xpub) : {master_fpr : path}}]
             this_import['timestamp'] = 'now'

--- a/hwi.py
+++ b/hwi.py
@@ -200,7 +200,7 @@ def process_commands():
             xpub = json.loads(client.get_pubkey_at_path(path))['xpub']
             address = xpub_to_address(xpub, args.testnet)
             this_import['scriptPubKey'] = {'address' : address}
-            this_import['pubkeys'] = [{xpub_to_pub_hex(xpub) : {master_fpr : path}}]
+            this_import['pubkeys'] = [{xpub_to_pub_hex(xpub) : {master_fpr : path.replace('\'', 'h')}}]
             this_import['timestamp'] = 'now'
             import_data.append(this_import)
         print(json.dumps(import_data))

--- a/hwi.py
+++ b/hwi.py
@@ -173,7 +173,7 @@ def process_commands():
             import traceback
             traceback.print_exc()
             print(json.dumps({'error':'You must provide a PSBT','code':INVALID_TX}))
-            exit
+            return
         print(json.dumps(client.sign_tx(tx)))
 
     elif command == 'getxpub':

--- a/hwi.py
+++ b/hwi.py
@@ -9,7 +9,7 @@ import json
 from device_ids import trezor_device_ids, keepkey_device_ids, ledger_device_ids,\
                         digitalbitbox_device_ids
 from serializations import PSBT, Base64ToHex, HexToBase64, hash160
-from base58 import xpub_to_address, xpub_to_pub_hex, get_xpub_id
+from base58 import xpub_to_address, xpub_to_pub_hex, get_xpub_fingerprint_as_id
 
 # Error codes
 NO_DEVICE_PATH = -1
@@ -184,11 +184,11 @@ def process_commands():
         # args[0]: path base (e.g. m/44'/0'/0')
         # args[1]; start index (e.g. 0)
         # args[2]: end index (e.g. 1000)
-        master_xpub = json.loads(client.get_pubkey_at_path('m/'))['xpub']
-        master_fpr = get_xpub_id(master_xpub)
         path_base = command_args[0]
         start = int(command_args[1])
         end = int(command_args[2])
+        master_xpub = json.loads(client.get_pubkey_at_path('m/0h'))['xpub']
+        master_fpr = get_xpub_fingerprint_as_id(master_xpub)
 
         import_data = []
         for i in range(start, end + 1):

--- a/keepkeyi.py
+++ b/keepkeyi.py
@@ -30,6 +30,8 @@ class KeepKeyClient(HardwareWalletClient):
     # Must return a dict with the xpub
     # Retrieves the public key at the specified BIP 32 derivation path
     def get_pubkey_at_path(self, path):
+        path = path.replace('h', '\'')
+        path = path.replace('H', '\'')
         expanded_path = self.client.expand_path(path)
         output = self.client.get_public_node(expanded_path)
         if self.is_testnet:

--- a/keepkeyi.py
+++ b/keepkeyi.py
@@ -1,10 +1,12 @@
 # KeepKey interaction script
 
+from base58 import xpub_main_2_test
 from hwi import HardwareWalletClient
 from keepkeylib.transport_hid import HidTransport
 from keepkeylib.client import KeepKeyClient as KeepKey
 
 import binascii
+import json
 
 # This class extends the HardwareWalletClient for Digital Bitbox specific things
 class KeepKeyClient(HardwareWalletClient):
@@ -30,8 +32,10 @@ class KeepKeyClient(HardwareWalletClient):
     def get_pubkey_at_path(self, path):
         expanded_path = self.client.expand_path(path)
         output = self.client.get_public_node(expanded_path)
-        print({'xpub':output.xpub})
-        return
+        if self.is_testnet:
+            return json.dumps({'xpub':xpub_main_2_test(output.xpub)})
+        else:
+            return json.dumps({'xpub':output.xpub})
 
     # Must return a hex string with the signed transaction
     # The tx must be in the combined unsigned transaction format

--- a/ledgeri.py
+++ b/ledgeri.py
@@ -25,6 +25,8 @@ class LedgerClient(HardwareWalletClient):
     # Retrieves the public key at the specified BIP 32 derivation path
     def get_pubkey_at_path(self, path):
         path = path[2:]
+        path = path.replace('h', '\'')
+        path = path.replace('H', '\'')
         # This call returns raw uncompressed pubkey, chaincode
         pubkey = self.app.getWalletPublicKey(path)
         if path != "":
@@ -40,7 +42,7 @@ class LedgerClient(HardwareWalletClient):
             # Compute child info
             childstr = path.split("/")[-1]
             hard = 0
-            if childstr[-1] == "'":
+            if childstr[-1] == "'" or childstr[-1] == "h" or childstr[-1] == "H":
                 childstr = childstr[:-1]
                 hard = 0x80000000
             child = struct.pack(">I", int(childstr)+hard)

--- a/ledgeri.py
+++ b/ledgeri.py
@@ -55,7 +55,10 @@ class LedgerClient(HardwareWalletClient):
         depth = len(path.split("/")) if len(path) > 0 else 0
         depth = struct.pack("B", depth)
 
-        version = bytearray.fromhex("0488B21E")
+        if self.is_testnet:
+            version = bytearray.fromhex("043587CF")
+        else:
+            version = bytearray.fromhex("0488B21E")
         extkey = version+depth+fpr+child+chainCode+publicKey
         checksum = hash256(extkey)[:4]
 


### PR DESCRIPTION
Instead of using the actual master seed id, use the fingerprint and pack that into a uint160. Otherwise wallets which do not support fetching the master pubkey or its id will not work. By packing it into a uint160, we can still ensure that the fingerprint is actually used.

Also allow using `h` and `H` to indicate hardened to avoid having to escape `'` in the terminal.

Built on top of #11 so I could test the thing.