### PR TITLE
Trezor and keepkey signtx support

### DIFF
--- a/bech32.py
+++ b/bech32.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2017 Pieter Wuille
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Reference implementation for Bech32 and segwit addresses."""
+
+
+CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+
+def bech32_polymod(values):
+    """Internal function that computes the Bech32 checksum."""
+    generator = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+    chk = 1
+    for value in values:
+        top = chk >> 25
+        chk = (chk & 0x1ffffff) << 5 ^ value
+        for i in range(5):
+            chk ^= generator[i] if ((top >> i) & 1) else 0
+    return chk
+
+
+def bech32_hrp_expand(hrp):
+    """Expand the HRP into values for checksum computation."""
+    return [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
+
+
+def bech32_verify_checksum(hrp, data):
+    """Verify a checksum given HRP and converted data characters."""
+    return bech32_polymod(bech32_hrp_expand(hrp) + data) == 1
+
+
+def bech32_create_checksum(hrp, data):
+    """Compute the checksum values given HRP and data."""
+    values = bech32_hrp_expand(hrp) + data
+    polymod = bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ 1
+    return [(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
+
+
+def bech32_encode(hrp, data):
+    """Compute a Bech32 string given HRP and data values."""
+    combined = data + bech32_create_checksum(hrp, data)
+    return hrp + '1' + ''.join([CHARSET[d] for d in combined])
+
+
+def bech32_decode(bech):
+    """Validate a Bech32 string, and determine HRP and data."""
+    if ((any(ord(x) < 33 or ord(x) > 126 for x in bech)) or
+            (bech.lower() != bech and bech.upper() != bech)):
+        return (None, None)
+    bech = bech.lower()
+    pos = bech.rfind('1')
+    if pos < 1 or pos + 7 > len(bech) or len(bech) > 90:
+        return (None, None)
+    if not all(x in CHARSET for x in bech[pos+1:]):
+        return (None, None)
+    hrp = bech[:pos]
+    data = [CHARSET.find(x) for x in bech[pos+1:]]
+    if not bech32_verify_checksum(hrp, data):
+        return (None, None)
+    return (hrp, data[:-6])
+
+
+def convertbits(data, frombits, tobits, pad=True):
+    """General power-of-2 base conversion."""
+    acc = 0
+    bits = 0
+    ret = []
+    maxv = (1 << tobits) - 1
+    max_acc = (1 << (frombits + tobits - 1)) - 1
+    for value in data:
+        if value < 0 or (value >> frombits):
+            return None
+        acc = ((acc << frombits) | value) & max_acc
+        bits += frombits
+        while bits >= tobits:
+            bits -= tobits
+            ret.append((acc >> bits) & maxv)
+    if pad:
+        if bits:
+            ret.append((acc << (tobits - bits)) & maxv)
+    elif bits >= frombits or ((acc << (tobits - bits)) & maxv):
+        return None
+    return ret
+
+
+def decode(hrp, addr):
+    """Decode a segwit address."""
+    hrpgot, data = bech32_decode(addr)
+    if hrpgot != hrp:
+        return (None, None)
+    decoded = convertbits(data[1:], 5, 8, False)
+    if decoded is None or len(decoded) < 2 or len(decoded) > 40:
+        return (None, None)
+    if data[0] > 16:
+        return (None, None)
+    if data[0] == 0 and len(decoded) != 20 and len(decoded) != 32:
+        return (None, None)
+    return (data[0], decoded)
+
+
+def encode(hrp, witver, witprog):
+    """Encode a segwit address."""
+    ret = bech32_encode(hrp, [witver] + convertbits(witprog, 8, 5))
+    if decode(hrp, ret) == (None, None):
+        return None
+    return ret

--- a/keepkeyi.py
+++ b/keepkeyi.py
@@ -1,12 +1,48 @@
 # KeepKey interaction script
 
-from base58 import xpub_main_2_test
 from hwi import HardwareWalletClient
 from keepkeylib.transport_hid import HidTransport
 from keepkeylib.client import KeepKeyClient as KeepKey
+from keepkeylib import tools
+from keepkeylib import messages_pb2, types_pb2 as proto
+from keepkeylib.tx_api import TxApi
+from base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test
+from serializations import ser_uint256, uint256_from_str
 
 import binascii
 import json
+
+class TxAPIPSBT(TxApi):
+
+    def __init__(self, psbt):
+        super().__init__('bitcoin_psbt', None)
+        self.psbt = psbt
+
+    def get_tx(self, txhash):
+        tx = None
+        for psbt_in in self.psbt.inputs:
+            if psbt_in.non_witness_utxo and psbt_in.non_witness_utxo.sha256 == uint256_from_str(binascii.unhexlify(txhash)[::-1]):
+                tx = psbt_in.non_witness_utxo
+        if not tx:
+            raise ValueError("TX {} not found in PSBT".format(txhash))
+
+        t = proto.TransactionType()
+        t.version = tx.nVersion
+        t.lock_time = tx.nLockTime
+
+        for vin in tx.vin:
+            i = t.inputs.add()
+            i.prev_hash = ser_uint256(vin.prevout.hash)[::-1]
+            i.prev_index = vin.prevout.n
+            i.script_sig = vin.scriptSig
+            i.sequence = vin.nSequence
+
+        for vout in tx.vout:
+            o = t.bin_outputs.add()
+            o.amount = vout.nValue
+            o.script_pubkey = vout.scriptPubKey
+
+        return t
 
 # This class extends the HardwareWalletClient for Digital Bitbox specific things
 class KeepKeyClient(HardwareWalletClient):
@@ -42,8 +78,100 @@ class KeepKeyClient(HardwareWalletClient):
     # Must return a hex string with the signed transaction
     # The tx must be in the combined unsigned transaction format
     def sign_tx(self, tx):
-        raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+
+        # Get this devices master key fingerprint
+        master_key = self.client.get_public_node([0])
+        master_fp = get_xpub_fingerprint(master_key.xpub)
+
+        # Prepare inputs
+        inputs = []
+        for psbt_in, txin in zip(tx.inputs, tx.tx.vin):
+            txinputtype = proto.TxInputType()
+
+            # Set the input stuff
+            txinputtype.prev_hash = ser_uint256(txin.prevout.hash)[::-1]
+            txinputtype.prev_index = txin.prevout.n
+            txinputtype.sequence = txin.nSequence
+
+            # Check for 1 key
+            if len(psbt_in.hd_keypaths) == 1:
+                # Is this key ours
+                pubkey = list(psbt_in.hd_keypaths.keys())[0]
+                fp = psbt_in.hd_keypaths[pubkey][0]
+                keypath = psbt_in.hd_keypaths[pubkey][1:]
+                if fp == master_fp:
+                    # Set the keypath
+                    txinputtype.address_n.extend(keypath)
+                    if psbt_in.non_witness_utxo:
+                        txinputtype.script_type = 0
+                    elif psbt_in.witness_utxo:
+                        # Check if the output is p2sh
+                        if psbt_in.witness_utxo.is_p2sh():
+                            txinputtype.script_type = 3
+                        else:
+                            txinputtype.script_type = 4
+                else:
+                    raise TypeError("All inputs must have a key for this device")
+
+            # Check for multisig (more than 1 key)
+            elif len(psbt_in.hd_keypaths) > 1:
+                raise TypeError("Cannot sign multisig yet")
+            else:
+                raise TypeError("All inputs must have a key for this device")
+
+            # Set the amount
+            if psbt_in.non_witness_utxo:
+                txinputtype.amount = psbt_in.non_witness_utxo.vout[txin.prevout.n].nValue
+            elif psbt_in.witness_utxo:
+                txinputtype.amount = psbt_in.witness_utxo.nValue
+
+            # append to inputs
+            inputs.append(txinputtype)
+
+        # address version byte
+        if self.is_testnet:
+            p2pkh_version = b'\x6f'
+            p2sh_version = b'\xc4'
+        else:
+            p2pkh_version = b'\x00'
+            p2sh_version = b'\x05'
+
+        # prepare outputs
+        outputs = []
+        for out in tx.tx.vout:
+            txoutput = proto.TxOutputType()
+            txoutput.amount = out.nValue
+            if out.is_p2pkh():
+                txoutput.address = to_address(out.scriptPubKey[3:23], p2pkh_version)
+                txoutput.script_type = 0
+            elif out.is_p2sh():
+                txoutput.address = to_address(out.scriptPubKey[2:22], p2sh_version)
+                txoutput.script_type = 1
+            else:
+                # TODO: Figure out what to do here. for now, just break
+                break
+
+            # append to outputs
+            outputs.append(txoutput)
+            print(txoutput)
+
+        # Sign the transaction
+        self.client.set_tx_api(TxAPIPSBT(tx))
+        if self.is_testnet:
+            signed_tx = self.client.sign_tx("Testnet", inputs, outputs, tx.tx.nVersion, tx.tx.nLockTime)
+        else:
+            signed_tx = self.client.sign_tx("Bitcoin", inputs, outputs, tx.tx.nVersion, tx.tx.nLockTime)
+
+        signatures = signed_tx[0]
+        print(binascii.hexlify(signed_tx[1]))
+        for psbt_in in tx.inputs:
+            for pubkey, sig in zip(psbt_in.hd_keypaths.keys(), signatures):
+                fp = psbt_in.hd_keypaths[pubkey][0]
+                keypath = psbt_in.hd_keypaths[pubkey][1:]
+                if fp == master_fp:
+                    psbt_in.partial_sigs[pubkey] = sig + b'\x01'
+
+        return tx.serialize()
 
     # Must return a base64 encoded string with the signed message
     # The message can be any string

--- a/keepkeyi.py
+++ b/keepkeyi.py
@@ -93,6 +93,16 @@ class KeepKeyClient(HardwareWalletClient):
             txinputtype.prev_index = txin.prevout.n
             txinputtype.sequence = txin.nSequence
 
+            # Detrermine spend type
+            if psbt_in.non_witness_utxo:
+                txinputtype.script_type = 0
+            elif psbt_in.witness_utxo:
+                # Check if the output is p2sh
+                if psbt_in.witness_utxo.is_p2sh():
+                    txinputtype.script_type = 3
+                else:
+                    txinputtype.script_type = 4
+
             # Check for 1 key
             if len(psbt_in.hd_keypaths) == 1:
                 # Is this key ours
@@ -102,16 +112,6 @@ class KeepKeyClient(HardwareWalletClient):
                 if fp == master_fp:
                     # Set the keypath
                     txinputtype.address_n.extend(keypath)
-                    if psbt_in.non_witness_utxo:
-                        txinputtype.script_type = 0
-                    elif psbt_in.witness_utxo:
-                        # Check if the output is p2sh
-                        if psbt_in.witness_utxo.is_p2sh():
-                            txinputtype.script_type = 3
-                        else:
-                            txinputtype.script_type = 4
-                else:
-                    raise TypeError("All inputs must have a key for this device")
 
             # Check for multisig (more than 1 key)
             elif len(psbt_in.hd_keypaths) > 1:

--- a/serializations.py
+++ b/serializations.py
@@ -309,6 +309,18 @@ class CTxOut(object):
     def is_p2pk(self):
         return (len(self.scriptPubKey) == 35 or len(self.scriptPubKey) == 67) and (self.scriptPubKey[0] == 0x21 or self.scriptPubKey[0] == 0x41) and self.scriptPubKey[-1] == 0xac
 
+    def is_witness(self):
+        if len(self.scriptPubKey) < 4 or len(self.scriptPubKey) > 42:
+            return (False, None, None)
+
+        if self.scriptPubKey[0] != 0 and (self.scriptPubKey[0] < 81 or self.scriptPubKey[0] > 96):
+            return (False, None, None)
+
+        if self.scriptPubKey[1] + 2 == len(self.scriptPubKey):
+            return (True, self.scriptPubKey[0] - 0x50 if self.scriptPubKey[0] else 0, self.scriptPubKey[2:])
+
+        return (False, None, None)
+
     def __repr__(self):
         return "CTxOut(nValue=%i.%08i scriptPubKey=%s)" \
             % (self.nValue, self.nValue, binascii.hexlify(self.scriptPubKey))

--- a/serializations.py
+++ b/serializations.py
@@ -240,7 +240,7 @@ def ser_sig_compact(r, s, recid):
 MSG_WITNESS_FLAG = 1<<30
 
 class COutPoint(object):
-    def __init__(self, hash=0, n=0):
+    def __init__(self, hash=0, n=0xffffffff):
         self.hash = hash
         self.n = n
 
@@ -545,6 +545,7 @@ class PartiallySignedInput:
                 self.non_witness_utxo = CTransaction()
                 value = BufferedReader(BytesIO(deser_string(f)))
                 self.non_witness_utxo.deserialize(value)
+                self.non_witness_utxo.rehash()
 
             elif key_type == 1:
                 if self.witness_utxo:

--- a/test_bech32.py
+++ b/test_bech32.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2017 Pieter Wuille
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+"""Reference tests for segwit adresses"""
+
+import binascii
+import unittest
+import bech32 as segwit_addr
+
+def segwit_scriptpubkey(witver, witprog):
+    """Construct a Segwit scriptPubKey for a given witness program."""
+    return bytes([witver + 0x50 if witver else 0, len(witprog)] + witprog)
+
+VALID_CHECKSUM = [
+    "A12UEL5L",
+    "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+    "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
+    "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+    "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
+]
+
+INVALID_CHECKSUM = [
+    " 1nwldj5",
+    "\x7F" + "1axkwrx",
+    "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+    "pzry9x0s0muk",
+    "1pzry9x0s0muk",
+    "x1b4n0q5v",
+    "li1dgmt3",
+    "de1lg7wt\xff",
+]
+
+VALID_ADDRESS = [
+    ["BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", "0014751e76e8199196d454941c45d1b3a323f1433bd6"],
+    ["tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+     "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"],
+    ["bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+     "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6"],
+    ["BC1SW50QA3JX3S", "6002751e"],
+    ["bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "5210751e76e8199196d454941c45d1b3a323"],
+    ["tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
+     "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"],
+]
+
+INVALID_ADDRESS = [
+    "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+    "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+    "bc1rw5uspcuh",
+    "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+    "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+    "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
+    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+    "bc1gmk9yu",
+
+]
+
+INVALID_ADDRESS_ENC = [
+    ("BC", 0, 20),
+    ("bc", 0, 21),
+    ("bc", 17, 32),
+    ("bc", 1, 1),
+    ("bc", 16, 41),
+]
+
+class TestSegwitAddress(unittest.TestCase):
+    """Unit test class for segwit addressess."""
+
+    def test_valid_checksum(self):
+        """Test checksum creation and validation."""
+        for test in VALID_CHECKSUM:
+            hrp, _ = segwit_addr.bech32_decode(test)
+            self.assertIsNotNone(hrp)
+            pos = test.rfind('1')
+            test = test[:pos+1] + chr(ord(test[pos + 1]) ^ 1) + test[pos+2:]
+            hrp, _ = segwit_addr.bech32_decode(test)
+            self.assertIsNone(hrp)
+
+    def test_invalid_checksum(self):
+        """Test validation of invalid checksums."""
+        for test in INVALID_CHECKSUM:
+            hrp, _ = segwit_addr.bech32_decode(test)
+            self.assertIsNone(hrp)
+
+    def test_valid_address(self):
+        """Test whether valid addresses decode to the correct output."""
+        for (address, hexscript) in VALID_ADDRESS:
+            hrp = "bc"
+            witver, witprog = segwit_addr.decode(hrp, address)
+            if witver is None:
+                hrp = "tb"
+                witver, witprog = segwit_addr.decode(hrp, address)
+            self.assertIsNotNone(witver)
+            scriptpubkey = segwit_scriptpubkey(witver, witprog)
+            self.assertEqual(scriptpubkey, binascii.unhexlify(hexscript))
+            addr = segwit_addr.encode(hrp, witver, witprog)
+            self.assertEqual(address.lower(), addr)
+
+    def test_invalid_address(self):
+        """Test whether invalid addresses fail to decode."""
+        for test in INVALID_ADDRESS:
+            witver, _ = segwit_addr.decode("bc", test)
+            self.assertIsNone(witver)
+            witver, _ = segwit_addr.decode("tb", test)
+            self.assertIsNone(witver)
+
+    def test_invalid_address_enc(self):
+        """Test whether address encoding fails on invalid input."""
+        for hrp, version, length in INVALID_ADDRESS_ENC:
+            code = segwit_addr.encode(hrp, version, [0] * length)
+            self.assertIsNone(code)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trezori.py
+++ b/trezori.py
@@ -166,6 +166,8 @@ class TrezorClient(HardwareWalletClient):
                 keypath = psbt_in.hd_keypaths[pubkey][1:]
                 if fp == master_fp:
                     psbt_in.partial_sigs[pubkey] = sig + b'\x01'
+                break
+            signatures.remove(sig)
 
         return tx.serialize()
 


### PR DESCRIPTION
Fixes and adds signtx support for Trezor and KeepKey. Currently only single key signing is supported.

Only the Trezor one has been tested. I have not tested the KeepKey implementation yet because my device's firmware is outdated and I have not been able to update it yet.

Tested the Trezor implementation for non-segwit, p2sh-segwit, and bech32.

The bech32 implementation was added to support bech32 outputs as this is required by both Trezor and KeepKey.