### PR TITLE
Autodetect clients based on their master public key fingerprint

### DIFF
--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -71,6 +71,11 @@ def get_xpub_fingerprint(s):
     fingerprint = data[5:9]
     return struct.unpack("<I", fingerprint)[0]
 
+def get_xpub_fingerprint_hex(xpub):
+    data = decode(xpub)
+    fingerprint = data[5:9]
+    return hexlify(fingerprint).decode()
+
 def get_xpub_fingerprint_as_id(xpub):
     data = decode(xpub)
     fingerprint = data[5:9] + b'\x00' * 16

--- a/hwilib/coldcardi.py
+++ b/hwilib/coldcardi.py
@@ -17,6 +17,7 @@ class ColdCardClient(HardwareWalletClient):
 
     # device is an HID device that has already been opened.
     def __init__(self, device):
+        super(ColdCardClient, self).__init__(device)
         self.device = ColdcardDevice(dev=device)
 
     # Must return a dict with the xpub

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -12,7 +12,7 @@ import logging
 from .device_ids import trezor_device_ids, keepkey_device_ids, ledger_device_ids,\
                         digitalbitbox_device_ids, coldcard_device_ids
 from .serializations import PSBT, Base64ToHex, HexToBase64, hash160
-from .base58 import xpub_to_address, xpub_to_pub_hex, get_xpub_fingerprint_as_id
+from .base58 import xpub_to_address, xpub_to_pub_hex, get_xpub_fingerprint_as_id, get_xpub_fingerprint_hex
 from bip32utils import BIP32Key
 
 # Error codes
@@ -85,7 +85,8 @@ def enumerate():
 
         client = get_client(d_data['type'], d_data['path'])
         master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-        d_data['fingerprint'] = get_xpub_fingerprint_as_id(master_xpub)
+        d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+        client.close()
 
         result.append(d_data)
     return result
@@ -95,7 +96,7 @@ def find_device(fingerprint):
     for d in devices:
         client = get_client(d['type'], d['path'])
         master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-        master_fpr = get_xpub_fingerprint_as_id(master_xpub)
+        master_fpr = get_xpub_fingerprint_hex(master_xpub)
         if master_fpr == fingerprint:
             return client
         client.close()

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -100,6 +100,7 @@ def find_device(fingerprint):
         if master_fpr == fingerprint:
             return client
         client.close()
+    return None
 
 def getmasterxpub(args, client):
     return client.get_master_xpub()
@@ -222,8 +223,10 @@ def process_commands(args):
         return args.func()
 
     # Auto detect if that is set
-    if 'fingerprint' in args:
+    if args.fingerprint:
         client = find_device(args.fingerprint)
+        if not client:
+            return {'error':'Could not find device with specified fingerprint','code':DEVICE_CONN_ERROR}
     else:
         if device_path is None:
             return {'error':'You must specify a device path for all commands except enumerate','code':NO_DEVICE_PATH}

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -63,26 +63,32 @@ def enumerate():
     result = []
     devices = hid.enumerate()
     for d in devices:
+        d_data = {}
         # Get trezors
         if (d['vendor_id'], d['product_id']) in trezor_device_ids:
-            result.append({'type':'trezor','path':d['path'].decode("utf-8"),
-                'serial_number':d['serial_number']})
+            d_data['type'] = 'trezor'
         # Get keepkeys
         elif (d['vendor_id'], d['product_id']) in keepkey_device_ids:
-            result.append({'type':'keepkey', 'path':d['path'].decode("utf-8"),
-                'serial_number':d['serial_number']})
+            d_data['type'] = 'keepkey'
         # Get ledgers
         elif (d['vendor_id'], d['product_id']) in ledger_device_ids:
-            result.append({'type':'ledger', 'path':d['path'].decode("utf-8"),
-                'serial_number':d['serial_number']})
+            d_data['type'] = 'ledger'
         # Get DigitalBitboxes
         elif (d['vendor_id'], d['product_id']) in digitalbitbox_device_ids:
-            result.append({'type':'digitalbitbox', 'path':d['path'].decode("utf-8"),
-                'serial_number':d['serial_number']})
+            d_data['type'] = 'digitalbitbox'
         # Get ColdCards
         elif (d['vendor_id'], d['product_id']) in coldcard_device_ids:
-            result.append({'type':'coldcard', 'path':d['path'].decode("utf-8"),
-                'serial_number':d['serial_number']})
+            d_data['type'] = 'coldcard'
+        else:
+            continue
+        d_data['path'] = d['path'].decode("utf-8")
+        d_data['serial_number'] = d['serial_number']
+
+        client = get_client(d_data['type'], d_data['path'])
+        master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
+        d_data['fingerprint'] = get_xpub_fingerprint_as_id(master_xpub)
+
+        result.append(d_data)
     return result
 
 def find_device(fingerprint):

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -55,7 +55,6 @@ def get_client(device_type, device_path):
         client = coldcardi.ColdCardClient(device=device)
     else:
         return {'error':'Unknown device type specified','code':UNKNWON_DEVICE_TYPE}
-    client.is_testnet = args.testnet
     return client
 
 # Get a list of all available hardware wallets
@@ -231,6 +230,7 @@ def process_commands(args):
             return {'error':'You must specify a device type for all commands except enumerate','code':NO_DEVICE_TYPE}
 
         client = get_client(device_type, device_path)
+    client.is_testnet = args.testnet
 
     # Do the commands
     result = args.func(args, client)


### PR DESCRIPTION
This PR displays the master public key fingerprint in the enumerate output and allows for the user to specify the fingerprint instead of the device type and path so that the device can be automatically detected.