### PR TITLE
Improvements to handling device passwords

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -30,7 +30,7 @@ class UnknownDeviceError(Exception):
         Exception.__init__(self,*args,**kwargs)
 
 # Get the client for the device
-def get_client(device_type, device_path, password=None):
+def get_client(device_type, device_path, password=''):
     class_name = device_type.capitalize()
     module = device_type.lower()
 
@@ -187,7 +187,7 @@ def process_commands(args):
     parser = argparse.ArgumentParser(description='Access and send commands to a hardware wallet device. Responses are in JSON format')
     parser.add_argument('--device-path', '-d', help='Specify the device path of the device to connect to')
     parser.add_argument('--device-type', '-t', help='Specify the type of device that will be connected. If `--device-path` not given, the first device of this type enumerated is used.')
-    parser.add_argument('--password', '-p', help='Device password if it has one (e.g. DigitalBitbox)')
+    parser.add_argument('--password', '-p', help='Device password if it has one (e.g. DigitalBitbox)', default='')
     parser.add_argument('--stdinpass', help='Enter the device password on the command line', action='store_true')
     parser.add_argument('--testnet', help='Use testnet prefixes', action='store_true')
     parser.add_argument('--debug', help='Print debug statements', action='store_true')

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -9,6 +9,7 @@ import sys
 import logging
 import glob
 import importlib
+import getpass
 
 from .serializations import PSBT, Base64ToHex, HexToBase64, hash160
 from .base58 import xpub_to_address, xpub_to_pub_hex, get_xpub_fingerprint_as_id, get_xpub_fingerprint_hex
@@ -187,6 +188,7 @@ def process_commands(args):
     parser.add_argument('--device-path', '-d', help='Specify the device path of the device to connect to')
     parser.add_argument('--device-type', '-t', help='Specify the type of device that will be connected. If `--device-path` not given, the first device of this type enumerated is used.')
     parser.add_argument('--password', '-p', help='Device password if it has one (e.g. DigitalBitbox)')
+    parser.add_argument('--stdinpass', help='Enter the device password on the command line', action='store_true')
     parser.add_argument('--testnet', help='Use testnet prefixes', action='store_true')
     parser.add_argument('--debug', help='Print debug statements', action='store_true')
     parser.add_argument('--fingerprint', '-f', help='Specify the device to connect to using the first 4 bytes of the hash160 of the master public key. It will connect to the first device that matches this fingerprint.')
@@ -240,6 +242,11 @@ def process_commands(args):
 
     # Setup debug logging
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.WARNING)
+
+    # Enter the password on stdin
+    if args.stdinpass:
+        password = getpass.getpass('Enter your device password: ')
+        args.password = password
 
     # List all available hardware wallet devices
     if command == 'enumerate':

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -116,7 +116,7 @@ class ColdcardClient(HardwareWalletClient):
     def close(self):
         self.device.close()
 
-def enumerate(password=None):
+def enumerate(password=''):
     results = []
     for d in hid.enumerate(COINKITE_VID, CKCC_PID):
         d_data = {}

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -369,7 +369,7 @@ class DigitalbitboxClient(HardwareWalletClient):
     def close(self):
         self.device.close()
 
-def enumerate(password=None):
+def enumerate(password=''):
     results = []
     for d in hid.enumerate(DBB_VENDOR_ID, DBB_DEVICE_ID):
         if ('interface_number' in d and  d['interface_number'] == 0 \

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -195,7 +195,7 @@ class KeepkeyClient(HardwareWalletClient):
     def close(self):
         self.client.close()
 
-def enumerate(password=None):
+def enumerate(password=''):
     results = []
     for d in HidTransport.enumerate():
         d_data = {}

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -259,7 +259,7 @@ class LedgerClient(HardwareWalletClient):
     def close(self):
         self.dongle.close()
 
-def enumerate(password=None):
+def enumerate(password=''):
     results = []
     for d in hid.enumerate(LEDGER_VENDOR_ID, LEDGER_DEVICE_ID):
         if ('interface_number' in d and  d['interface_number'] == 0 \

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -34,7 +34,6 @@ class TrezorClient(HardwareWalletClient):
 
         os.environ['PASSPHRASE'] = password
 
-
     # Must return a dict with the xpub
     # Retrieves the public key at the specified BIP 32 derivation path
     def get_pubkey_at_path(self, path):
@@ -200,7 +199,7 @@ class TrezorClient(HardwareWalletClient):
     def close(self):
         self.client.close()
 
-def enumerate(password=None):
+def enumerate(password=''):
     results = []
     for dev in enumerate_devices():
         d_data = {}

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -14,6 +14,7 @@ from .. import bech32
 import binascii
 import json
 import logging
+import os
 
 # This class extends the HardwareWalletClient for Trezor specific things
 class TrezorClient(HardwareWalletClient):
@@ -30,6 +31,8 @@ class TrezorClient(HardwareWalletClient):
         # if it wasn't able to find a client, throw an error
         if not self.client:
             raise IOError("no Device")
+
+        os.environ['PASSPHRASE'] = password
 
 
     # Must return a dict with the xpub


### PR DESCRIPTION
Add an option to enter passwords via stdin instead of on the command line in order to prevent the password from going into shell history.

Allow trezor passwords to be provided on the command or in stdin. These passwords will be saved the password to the environment (trezorlib will look in the environment variables) for trezors so that users don't have to keep entering it over and over (trezorlib will prompt by default).