### PR TITLE
dont use Ledger's getDongle, to use properly specified device path

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -72,8 +72,10 @@ def enumerate(args):
         # Get keepkeys
         elif (d['vendor_id'], d['product_id']) in keepkey_device_ids:
             d_data['type'] = 'keepkey'
-        # Get ledgers
-        elif (d['vendor_id'], d['product_id']) in ledger_device_ids:
+        # Get ledgers, only take interface 0 to avoid HID keyboard
+        elif (d['vendor_id'], d['product_id']) in ledger_device_ids and \
+                ('interface_number' in d and  d['interface_number'] == 0 \
+                or ('usage_page' in d and d['usage_page'] == 0xffa0)):
             d_data['type'] = 'ledger'
         # Get DigitalBitboxes
         elif (d['vendor_id'], d['product_id']) in digitalbitbox_device_ids:

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -36,6 +36,7 @@ def get_client(device_type, device_path, password=None):
     device = hid.device()
     device_path = bytes(device_path.encode())
     device.open_path(device_path)
+    device.set_nonblocking(True)
 
     # Make a client
     if device_type == 'trezor':

--- a/hwilib/ledgeri.py
+++ b/hwilib/ledgeri.py
@@ -18,9 +18,7 @@ class LedgerClient(HardwareWalletClient):
     # hacked in device support using btchip-python
     def __init__(self, device):
         super(LedgerClient, self).__init__(device)
-        # hack to use btchip-python's getDongle pipeline
-        device.close()
-        self.dongle = getDongle(logging.getLogger().getEffectiveLevel() == logging.DEBUG)
+        self.dongle = HIDDongleHIDAPI(device, True, logging.getLogger().getEffectiveLevel() == logging.DEBUG)
         self.app = btchip(self.dongle)
         self.device = device
 


### PR DESCRIPTION
Currently specifying the device path doesn't really do anything aside from error if that device path specified doesn't exist at all.

As another side-effect is enumerate shows an error for the keyboard HID instead of falsely reporting a fingerprint for it:

```
[{"path": "0001:XXX:00", "type": "ledger", "serial_number": "0001", "fingerprint": "deadbeef"}, {"error": "Could not open client or get fingerprint information: Exception : Invalid sequence", "path": "0001:XXX:01", "type": "ledger", "serial_number": "0001"}]
```