### PR TITLE
Increase default logging level to warning

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -281,7 +281,7 @@ def process_commands(args):
     command = args.command
 
     # Setup debug logging
-    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.WARNING)
 
     # List all available hardware wallet devices
     if command == 'enumerate':


### PR DESCRIPTION
`trezorlib` outputs stuff with logging level info which results in fairly verbose output. That output is not particularly useful, so increase the logging level to warning to suppress that output.