### PR TITLE
Trezor: displayaddress

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -180,8 +180,14 @@ class TrezorClient(HardwareWalletClient):
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
-        raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+      expanded_path = tools.parse_path(keypath)
+      output = btc.get_address(
+        self.client,
+        "Testnet" if self.is_testnet else "Bitcoin",
+        expanded_path,
+        show_display=True,
+        script_type=proto.InputScriptType.SPENDWITNESS if bech32 else (proto.InputScriptType.SPENDP2SHWITNESS if p2sh_p2wpkh else proto.InputScriptType.SPENDADDRESS)
+      )
 
     # Setup a new device
     def setup_device(self):

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -243,6 +243,14 @@ keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--path',
 assert(keypool_desc['error'] == 'Path must end with /*')
 assert(keypool_desc['code'] == -7)
 
+# Test displayaddress
+logging.info('Testing displayaddress legacy')
+process_commands(dev_args + ['displayaddress', 'm/44h/1h/0h/0/0'])
+logging.info('Testing displayaddress p2sh segwit')
+process_commands(dev_args + ['displayaddress', '--sh_wpkh', 'm/49h/1h/0h/0/0'])
+logging.info('Testing displayaddress native segwit')
+process_commands(dev_args + ['displayaddress', '--wpkh', 'm/84h/1h/0h/0/0'])
+
 # Test signtx
 logging.info('Testing signtx')
 # Import some keys to the watch only wallet and send coins to them


### PR DESCRIPTION
Tested with Trezor T for mainnet, testnet using legacy, p2sh-wrapped and native Segwit addressees.