### PR TITLE
Fix trezor implementation to work with python-trezor 0.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['docs', 'test']),
     install_requires=[
         'hidapi', # HID API needed in general
-        'trezor[hidapi]', # Trezor One
+        'trezor>=0.11.0', # Trezor One
         'btchip-python', # Ledger Nano S
         'keepkey', # KeepKey
         'ckcc-protocol', # Coldcard

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -14,8 +14,8 @@ import time
 from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
 from trezorlib.transport import enumerate_devices
 from trezorlib.transport.udp import UdpTransport
-from trezorlib.client import TrezorClientDebugLink
-from trezorlib import coins
+from trezorlib.debuglink import TrezorClientDebugLink, load_device_by_mnemonic, load_device_by_xprv
+from trezorlib import device
 
 from hwilib.commands import process_commands
 
@@ -56,13 +56,9 @@ for dev in enumerate_devices():
     if isinstance(dev, UdpTransport):
         wirelink = dev
         break
-debuglink = wirelink.find_debug()
 client = TrezorClientDebugLink(wirelink)
-client.set_debuglink(debuglink)
-client.set_tx_api(coins.tx_api['Bitcoin'])
-client.wipe_device()
-client.transport.session_begin()
-client.load_device_by_mnemonic(mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=False, label='test') # From Trezor device tests
+device.wipe(client)
+load_device_by_mnemonic(client=client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=False, label='test') # From Trezor device tests
 
 # Tests!
 
@@ -104,8 +100,8 @@ with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/bip32_
     vectors = json.load(f)
 for vec in vectors:
     # Setup with xprv
-    client.wipe_device()
-    client.load_device_by_xprv(xprv=vec['xprv'], pin='', passphrase_protection=False, label='test', language='english')
+    device.wipe(client)
+    load_device_by_xprv(client=client, xprv=vec['xprv'], pin='', passphrase_protection=False, label='test', language='english')
 
     # Test getmasterxpub
     gmxp_res = process_commands(dev_args + ['getmasterxpub'])


### PR DESCRIPTION
python-trezor 0.11.0 changed a bunch of their api stuff, so this updates the trezor implementation to work with 0.11.0. The minimum trezor library version is also set in setup.py.