### PR TITLE
Change tests to use unittest and some bug fixes as a result of this

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -147,7 +147,7 @@ class TrezorClient(HardwareWalletClient):
                     o = proto.TxOutputBinType()
                     o.amount = vout.nValue
                     o.script_pubkey = vout.scriptPubKey
-                    t.output.append(o)
+                    t.bin_outputs.append(o)
                 logging.debug(psbt_in.non_witness_utxo.hash)
                 prevtxs[ser_uint256(psbt_in.non_witness_utxo.sha256)[::-1]] = t
 

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -767,6 +767,7 @@ class PSBT(object):
     def deserialize(self, psbt):
         hexstring = Base64ToHex(psbt.strip())
         f = BufferedReader(BytesIO(binascii.unhexlify(hexstring)))
+        end = len(binascii.unhexlify(hexstring))
 
         # Read the magic bytes
         magic = f.read(5)
@@ -820,6 +821,8 @@ class PSBT(object):
 
         # Read input data
         for txin in self.tx.vin:
+            if f.tell() == end:
+                break
             input = PartiallySignedInput()
             input.deserialize(f)
             self.inputs.append(input)
@@ -832,6 +835,8 @@ class PSBT(object):
 
         # Read output data
         for txout in self.tx.vout:
+            if f.tell() == end:
+                break
             output = PartiallySignedOutput()
             output.deserialize(f)
             self.outputs.append(output)

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -2,251 +2,48 @@
 
 import argparse
 import atexit
-import logging
-import json
 import os
-import shutil
-import socket
 import subprocess
-import tempfile
 import time
+import unittest
 
-from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
 from hwilib.commands import process_commands
 from ckcc.protocol import CCProtocolPacker
 from ckcc.client import ColdcardDevice
+from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestGetKeypool, TestSignTx
 
-parser = argparse.ArgumentParser(description='Test Coldcard implementation')
-parser.add_argument('simulator', help='Path to the Coldcard simulator')
-parser.add_argument('bitcoind', help='Path to bitcoind binary')
-args = parser.parse_args()
-
-dev_args = ['-t', 'coldcard', '-d', '/tmp/ckcc-simulator.sock']
-
-# Setup logging
-logging.basicConfig(format='Coldcard Test: %(message)s', level=logging.INFO)
-
-# Start the Coldcard simulator
-logging.info('Starting Coldcard simulator')
-simulator_proc = subprocess.Popen(['python3', os.path.basename(args.simulator)], cwd=os.path.dirname(args.simulator))
-# Wait for simulator to be up
-while True:
-    enum_res = process_commands(['enumerate'])
-    if len(enum_res) > 0 and 'error' not in enum_res[0]:
-        break
-    time.sleep(0.5)
-# Cleanup
-def cleanup_simulator():
-    dev = ColdcardDevice(sn='/tmp/ckcc-simulator.sock')
-    resp = dev.send_recv(CCProtocolPacker.logout())
-atexit.register(cleanup_simulator)
-
-# Tests!
-
-# Test enumerate
-logging.info('Testing enumerate')
-enum_res = process_commands(['enumerate'])
-assert(len(enum_res) == 1)
-assert('error' not in enum_res[0])
-assert(enum_res[0]['type'] == 'coldcard')
-assert(enum_res[0]['path'] == '/tmp/ckcc-simulator.sock')
-assert(enum_res[0]['fingerprint'] == '0f056943')
-
-# Test path + type
-logging.info('Testing path and type not specified')
-gmxp_res = process_commands(['getmasterxpub'])
-assert('error' in gmxp_res)
-assert(gmxp_res['error'] == 'You must specify a device type or fingerprint for all commands except enumerate')
-assert('code' in gmxp_res)
-assert(gmxp_res['code'] == -1)
-
-logging.info('Testing path and type specified')
-gmxp_res = process_commands(['-t', enum_res[0]['type'], '-d', enum_res[0]['path'], 'getmasterxpub'])
-assert(gmxp_res['xpub'] == 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd')
-
-# Test fingerprint autodetect
-logging.info('Testing fingerprint autodetect')
-gmxp_res = process_commands(['-f', enum_res[0]['fingerprint'], 'getmasterxpub'])
-assert(gmxp_res['xpub'] == 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd')
-
-# Test device type autodetect
-logging.info('Testing only device type specified')
-gmxp_res = process_commands(['-t', enum_res[0]['type'], 'getmasterxpub'])
-assert(gmxp_res['xpub'] == 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd')
-
-# Test getxpub
-# BIP 32 test vectors
-logging.info('Testing getxpub and getmasterxpub')
-with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/coldcard_xpubs.json'), encoding='utf-8') as f:
-    vectors = json.load(f)
-for vec in vectors:
-    # Test getmasterxpub
-    gmxp_res = process_commands(dev_args + ['getmasterxpub'])
-    assert(gmxp_res['xpub'] == vec['master_xpub'])
-
-    # Test the path derivs
-    for path_vec in vec['vectors']:
-        gxp_res = process_commands(dev_args + ['getxpub', path_vec['path']])
-        assert(gxp_res['xpub'] == path_vec['xpub'])
-
-# signtx and getkeypool need bitcoind, so start that
-logging.info('Setting up bitcoind')
-datadir = tempfile.mkdtemp()
-bitcoind_proc = subprocess.Popen([args.bitcoind, '-regtest', '-datadir=' + datadir, '-noprinttoconsole'])
-def cleanup_bitcoind():
-    bitcoind_proc.kill()
-    shutil.rmtree(datadir)
-atexit.register(cleanup_bitcoind)
-# Wait for cookie file to be created
-while not os.path.exists(datadir + '/regtest/.cookie'):
-    time.sleep(0.5)
-# Read .cookie file to get user and pass
-with open(datadir + '/regtest/.cookie') as f:
-    userpass = f.readline().lstrip().rstrip()
-rpc = AuthServiceProxy('http://{}@127.0.0.1:18443'.format(userpass))
-
-# Wait for bitcoind to be ready
-ready = False
-while not ready:
-    try:
-        rpc.getblockchaininfo()
-        ready = True
-    except JSONRPCException as e:
+def coldcard_test_suite(simulator, rpc, userpass):
+    # Start the Coldcard simulator
+    simulator_proc = subprocess.Popen(['python3', os.path.basename(simulator)], cwd=os.path.dirname(simulator), stdout=subprocess.DEVNULL)
+    # Wait for simulator to be up
+    while True:
+        enum_res = process_commands(['enumerate'])
+        if len(enum_res) > 0 and 'error' not in enum_res[0]:
+            break
         time.sleep(0.5)
-        pass
+    # Cleanup
+    def cleanup_simulator():
+        dev = ColdcardDevice(sn='/tmp/ckcc-simulator.sock')
+        resp = dev.send_recv(CCProtocolPacker.logout())
+    atexit.register(cleanup_simulator)
 
-# Setup bitcoind with no privkey wallet and some blocks
-rpc.generatetoaddress(101, rpc.getnewaddress())
-rpc.createwallet('coldcard_test', True)
-wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/coldcard_test'.format(userpass))
-wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(userpass))
+    # Generic device tests
+    suite = unittest.TestSuite()
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
+    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
+    # HACK: Skip this in headless simulator because it requires user input
+    if not simulator.endswith('headless.py'):
+        suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
+    return suite
 
-# Since this is regtest, we need to use regtest in our args
-dev_args.append('--testnet')
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test Coldcard implementation')
+    parser.add_argument('simulator', help='Path to the Coldcard simulator')
+    parser.add_argument('bitcoind', help='Path to bitcoind binary')
+    args = parser.parse_args()
 
-# Test getkeypool
-logging.info('Testing getkeypool: Importable to privkey enabled wallet')
-non_keypool_desc = process_commands(dev_args + ['getkeypool', '0', '20'])
-import_result = wpk_rpc.importmulti(non_keypool_desc)
-assert(import_result[0]['success'])
+    # Start bitcoind
+    rpc, userpass = start_bitcoind(args.bitcoind)
 
-logging.info('Testing getkeypool: Not importable to privkey enabled wallet')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '0', '20'])
-import_result = wpk_rpc.importmulti(keypool_desc)
-assert(import_result[0]['success'] == False)
-
-logging.info('Testing getkeypool: Imports to non privkey enabled wallet keypool')
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/44'/1'/0'/0/{}".format(i))
-
-logging.info('Testing getkeypool: Imports to non privkey enabled wallet internal keypool')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--internal', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/44'/1'/0'/1/{}".format(i))
-
-logging.info('Testing getkeypool: --sh_wpkh uses correct derivation path')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/49'/1'/0'/0/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/49'/1'/0'/1/{}".format(i))
-
-logging.info('Testing getkeypool: --wpkh uses correct derivation path')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--wpkh', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/84'/1'/0'/0/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--wpkh', '--internal', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/84'/1'/0'/1/{}".format(i))
-
-logging.info('Testing getkeypool: --account uses correct derivation path')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--account', '3', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/49'/1'/3'/0/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '--account', '3', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/49'/1'/3'/1/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--wpkh', '--account', '3', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/84'/1'/3'/0/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--wpkh', '--internal', '--account', '3', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/84'/1'/3'/1/{}".format(i))
-
-logging.info('Testing getkeypool: --path uses correct derivation path')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--path', 'm/0h/0h/4h/*', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/0'/0'/4'/{}".format(i))
-
-logging.info('Testing getkeypool: check --path parse failures')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--path', '/0h/0h/4h/*', '0', '20'])
-assert(keypool_desc['error'] == 'Path must start with m/')
-assert(keypool_desc['code'] == -7)
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--path', 'm/0h/0h/4h/', '0', '20'])
-assert(keypool_desc['error'] == 'Path must end with /*')
-assert(keypool_desc['code'] == -7)
-
-# Test signtx
-# HACK: Skip this in headless simulator because it requires user input
-if not args.simulator.endswith('headless.py'):
-    logging.info('Testing signtx')
-    # Import some keys to the watch only wallet and send coins to them
-    keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '30', '40'])
-    import_result = wrpc.importmulti(keypool_desc)
-    assert(import_result[0]['success'])
-    keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '30', '40'])
-    import_result = wrpc.importmulti(keypool_desc)
-    assert(import_result[0]['success'])
-    sh_wpkh_addr = wrpc.getnewaddress('', 'p2sh-segwit')
-    wpkh_addr = wrpc.getnewaddress('', 'bech32')
-    pkh_addr = wrpc.getnewaddress('', 'legacy')
-    wrpc.importaddress(wpkh_addr)
-    wrpc.importaddress(pkh_addr)
-    wpk_rpc.sendtoaddress(sh_wpkh_addr, 10)
-    wpk_rpc.sendtoaddress(wpkh_addr, 10)
-    wpk_rpc.sendtoaddress(pkh_addr, 10)
-    wpk_rpc.generatetoaddress(6, wpk_rpc.getnewaddress())
-
-    # Create a psbt spending the above
-    psbt = wrpc.walletcreatefundedpsbt([], [{wpk_rpc.getnewaddress():10}], 0, {'includeWatching': True, 'subtractFeeFromOutputs': [0]}, True)
-    sign_res = process_commands(dev_args + ['signtx', psbt['psbt']])
-    finalize_res = wrpc.finalizepsbt(sign_res['psbt'])
-    assert(finalize_res['complete'])
-    wrpc.sendrawtransaction(finalize_res['hex'])
-
-# Done
-logging.info('PASS')
+    suite = coldcard_test_suite(args.simulator, rpc, userpass)
+    unittest.TextTestRunner().run(suite)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -1,0 +1,226 @@
+#! /usr/bin/env python3
+
+import atexit
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from hwilib.commands import process_commands
+
+def start_bitcoind(bitcoind_path):
+    datadir = tempfile.mkdtemp()
+    bitcoind_proc = subprocess.Popen([bitcoind_path, '-regtest', '-datadir=' + datadir, '-noprinttoconsole'])
+    def cleanup_bitcoind():
+        bitcoind_proc.kill()
+        shutil.rmtree(datadir)
+    atexit.register(cleanup_bitcoind)
+    # Wait for cookie file to be created
+    while not os.path.exists(datadir + '/regtest/.cookie'):
+        time.sleep(0.5)
+    # Read .cookie file to get user and pass
+    with open(datadir + '/regtest/.cookie') as f:
+        userpass = f.readline().lstrip().rstrip()
+    rpc = AuthServiceProxy('http://{}@127.0.0.1:18443'.format(userpass))
+
+    # Wait for bitcoind to be ready
+    ready = False
+    while not ready:
+        try:
+            rpc.getblockchaininfo()
+            ready = True
+        except JSONRPCException as e:
+            time.sleep(0.5)
+            pass
+
+    # Make sure there are blocks and coins available
+    rpc.generatetoaddress(101, rpc.getnewaddress())
+    return (rpc, userpass)
+
+class DeviceTestCase(unittest.TestCase):
+    def __init__(self, rpc, rpc_userpass, type, path, fingerprint, master_xpub, methodName='runTest'):
+        super(DeviceTestCase, self).__init__(methodName)
+        self.rpc = rpc
+        self.rpc_userpass = rpc_userpass
+        self.type = type
+        self.path = path
+        self.fingerprint = fingerprint
+        self.master_xpub = master_xpub
+        self.dev_args = ['-t', self.type, '-d', self.path]
+
+    @staticmethod
+    def parameterize(testclass, rpc, rpc_userpass, type, path, fingerprint, master_xpub):
+        testloader = unittest.TestLoader()
+        testnames = testloader.getTestCaseNames(testclass)
+        suite = unittest.TestSuite()
+        for name in testnames:
+            suite.addTest(testclass(rpc, rpc_userpass, type, path, fingerprint, master_xpub, name))
+        return suite
+
+class TestDeviceConnect(DeviceTestCase):
+    def test_enumerate(self):
+        enum_res = process_commands(['enumerate'])
+        found = False
+        for device in enum_res:
+            self.assertNotIn('error', device)
+            if device['type'] == self.type and device['path'] == self.path and device['fingerprint'] == self.fingerprint:
+                found = True
+        self.assertTrue(found)
+
+    def test_no_type(self):
+        gmxp_res = process_commands(['getmasterxpub'])
+        self.assertIn('error', gmxp_res)
+        self.assertEqual(gmxp_res['error'], 'You must specify a device type or fingerprint for all commands except enumerate')
+        self.assertIn('code', gmxp_res)
+        self.assertEqual(gmxp_res['code'], -1)
+
+    def test_path_type(self):
+        gmxp_res = process_commands(['-t', self.type, '-d', self.path, 'getmasterxpub'])
+        self.assertEqual(gmxp_res['xpub'], self.master_xpub)
+
+    def test_fingerprint_autodetect(self):
+        gmxp_res = process_commands(['-f', self.fingerprint, 'getmasterxpub'])
+        self.assertEqual(gmxp_res['xpub'], self.master_xpub)
+
+    def test_type_only_autodetech(self):
+        gmxp_res = process_commands(['-t', self.type, 'getmasterxpub'])
+        self.assertEqual(gmxp_res['xpub'], self.master_xpub)
+
+class TestGetKeypool(DeviceTestCase):
+    def setUp(self):
+        if '{}_test'.format(self.type) not in self.rpc.listwallets():
+            self.rpc.createwallet('{}_test'.format(self.type), True)
+        self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.type))
+        self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
+        if '--testnet' not in self.dev_args:
+            self.dev_args.append('--testnet')
+
+    def test_getkeypool(self):
+        non_keypool_desc = process_commands(self.dev_args + ['getkeypool', '0', '20'])
+        import_result = self.wpk_rpc.importmulti(non_keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '0', '20'])
+        import_result = self.wpk_rpc.importmulti(keypool_desc)
+        self.assertFalse(import_result[0]['success'])
+
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/44'/1'/0'/0/{}".format(i))
+
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--internal', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/44'/1'/0'/1/{}".format(i))
+
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/49'/1'/0'/0/{}".format(i))
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/49'/1'/0'/1/{}".format(i))
+
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--wpkh', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/84'/1'/0'/0/{}".format(i))
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--wpkh', '--internal', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/84'/1'/0'/1/{}".format(i))
+
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--account', '3', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/49'/1'/3'/0/{}".format(i))
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '--account', '3', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/49'/1'/3'/1/{}".format(i))
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--wpkh', '--account', '3', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/84'/1'/3'/0/{}".format(i))
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--wpkh', '--internal', '--account', '3', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/84'/1'/3'/1/{}".format(i))
+
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--path', 'm/0h/0h/4h/*', '0', '20'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        for i in range(0, 21):
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
+            self.assertEqual(addr_info['hdkeypath'], "m/0'/0'/4'/{}".format(i))
+
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--path', '/0h/0h/4h/*', '0', '20'])
+        self.assertEqual(keypool_desc['error'], 'Path must start with m/')
+        self.assertEqual(keypool_desc['code'], -7)
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--path', 'm/0h/0h/4h/', '0', '20'])
+        self.assertEqual(keypool_desc['error'], 'Path must end with /*')
+        self.assertEqual(keypool_desc['code'], -7)
+
+class TestSignTx(DeviceTestCase):
+    def setUp(self):
+        if '{}_test'.format(self.type) not in self.rpc.listwallets():
+            self.rpc.createwallet('{}_test'.format(self.type), True)
+        self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.type))
+        self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
+        if '--testnet' not in self.dev_args:
+            self.dev_args.append('--testnet')
+
+    def test_signtx(self):
+        # Import some keys to the watch only wallet and send coins to them
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '30', '40'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        keypool_desc = process_commands(self.dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '30', '40'])
+        import_result = self.wrpc.importmulti(keypool_desc)
+        self.assertTrue(import_result[0]['success'])
+        sh_wpkh_addr = self.wrpc.getnewaddress('', 'p2sh-segwit')
+        wpkh_addr = self.wrpc.getnewaddress('', 'bech32')
+        pkh_addr = self.wrpc.getnewaddress('', 'legacy')
+        self.wrpc.importaddress(wpkh_addr)
+        self.wrpc.importaddress(pkh_addr)
+        self.wpk_rpc.sendtoaddress(sh_wpkh_addr, 10)
+        self.wpk_rpc.sendtoaddress(wpkh_addr, 10)
+        self.wpk_rpc.sendtoaddress(pkh_addr, 10)
+        self.wpk_rpc.generatetoaddress(6, self.wpk_rpc.getnewaddress())
+
+        # Create a psbt spending the above
+        psbt = self.wrpc.walletcreatefundedpsbt([], [{self.wpk_rpc.getnewaddress():10}], 0, {'includeWatching': True, 'subtractFeeFromOutputs': [0]}, True)
+        sign_res = process_commands(self.dev_args + ['signtx', psbt['psbt']])
+        finalize_res = self.wrpc.finalizepsbt(sign_res['psbt'])
+        self.assertTrue(finalize_res['complete'])
+        self.wrpc.sendrawtransaction(finalize_res['hex'])
+
+class TestDisplayAddress(DeviceTestCase):
+    def test_display_address(self):
+        process_commands(self.dev_args + ['displayaddress', 'm/44h/1h/0h/0/0'])
+        process_commands(self.dev_args + ['displayaddress', '--sh_wpkh', 'm/49h/1h/0h/0/0'])
+        process_commands(self.dev_args + ['displayaddress', '--wpkh', 'm/84h/1h/0h/0/0'])

--- a/test/test_psbt.py
+++ b/test/test_psbt.py
@@ -1,36 +1,31 @@
 #! /usr/bin/env python3
 
-from hwilib.serializations import PSBT, Base64ToHex, HexToBase64
+from hwilib.serializations import PSBT
 import json
 import os
+import unittest
 
-print("Running PSBT Serialization Test")
+class TestPSBT(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Open the data file
+        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/test_psbt.json'), encoding='utf-8') as f:
+            cls.data = json.load(f)
 
-# Open the data file
-with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/test_psbt.json'), encoding='utf-8') as f:
-    d = json.load(f)
-    invalids = d['invalid']
-    valids = d['valid']
-    creators = d['creator']
-    signers = d['signer']
-    combiners = d['combiner']
-    finalizers = d['finalizer']
-    extractors = d['extractor']
+    def test_invalid_psbt(self):
+        for invalid in self.data['invalid']:
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(IOError) as cm:
+                    psbt = PSBT()
+                    psbt.deserialize(invalid)
 
-print("Testing invalid PSBTs")
-for invalid in invalids:
-    try:
-        psbt = PSBT()
-        psbt.deserialize(invalid)
-        assert False
-    except:
-        pass
+    def test_valid_psbt(self):
+        for valid in self.data['valid']:
+            with self.subTest(valid=valid):
+                psbt = PSBT()
+                psbt.deserialize(valid)
+                serd = psbt.serialize()
+                self.assertEqual(valid, serd)
 
-print("Testing valid PSBTs")
-for valid in valids:
-    psbt = PSBT()
-    psbt.deserialize(valid)
-    serd = psbt.serialize()
-    assert(valid == serd)
-
-print("PSBT Serialization tests pass")
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -2,280 +2,104 @@
 
 import argparse
 import atexit
-import logging
 import json
 import os
-import shutil
 import socket
 import subprocess
-import tempfile
 import time
+import unittest
 
 from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
 from trezorlib.transport import enumerate_devices
 from trezorlib.transport.udp import UdpTransport
 from trezorlib.debuglink import TrezorClientDebugLink, load_device_by_mnemonic, load_device_by_xprv
 from trezorlib import device
+from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignTx
 
 from hwilib.commands import process_commands
 
-parser = argparse.ArgumentParser(description='Test Trezor implementation')
-parser.add_argument('emulator', help='Path to the Trezor emulator')
-parser.add_argument('bitcoind', help='Path to bitcoind binary')
-args = parser.parse_args()
+def trezor_test_suite(emulator, rpc, userpass):
+    # Start the Trezor emulator
+    emulator_proc = subprocess.Popen([emulator])
+    # Wait for emulator to be up
+    # From https://github.com/trezor/trezor-mcu/blob/master/script/wait_for_emulator.py
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.connect(('127.0.0.1', 21324))
+    sock.settimeout(0)
+    while True:
+        try:
+            sock.sendall(b"PINGPING")
+            r = sock.recv(8)
+            if r == b"PONGPONG":
+                break
+        except Exception:
+            time.sleep(0.05)
+    # Cleanup
+    def cleanup_emulator():
+        emulator_proc.kill()
+    atexit.register(cleanup_emulator)
 
-dev_args = ['-t', 'trezor', '-d', 'udp:127.0.0.1:21324']
-
-# Setup logging
-logging.basicConfig(format='Trezor Test: %(message)s', level=logging.INFO)
-
-# Start the Trezor emulator
-logging.info('Starting Trezor emulator')
-emulator_proc = subprocess.Popen([args.emulator])
-# Wait for emulator to be up
-# From https://github.com/trezor/trezor-mcu/blob/master/script/wait_for_emulator.py
-sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-sock.connect(('127.0.0.1', 21324))
-sock.settimeout(0)
-while True:
-    try:
-        sock.sendall(b"PINGPING")
-        r = sock.recv(8)
-        if r == b"PONGPONG":
+    # Setup the emulator
+    for dev in enumerate_devices():
+        # Find the udp transport, that's the emulator
+        if isinstance(dev, UdpTransport):
+            wirelink = dev
             break
-    except Exception:
-        time.sleep(0.05)
-# Cleanup
-def cleanup_emulator():
-    emulator_proc.kill()
-atexit.register(cleanup_emulator)
-
-# Setup the emulator
-for dev in enumerate_devices():
-    # Find the udp transport, that's the emulator
-    if isinstance(dev, UdpTransport):
-        wirelink = dev
-        break
-client = TrezorClientDebugLink(wirelink)
-device.wipe(client)
-load_device_by_mnemonic(client=client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=False, label='test') # From Trezor device tests
-
-# Tests!
-
-# Test enumerate
-logging.info('Testing enumerate')
-enum_res = process_commands(['enumerate'])
-assert(len(enum_res) == 1)
-assert('error' not in enum_res[0])
-assert(enum_res[0]['type'] == 'trezor')
-assert(enum_res[0]['path'] == 'udp:127.0.0.1:21324')
-assert(enum_res[0]['fingerprint'] == '95d8f670')
-
-# Test path + type
-logging.info('Testing path and type not specified')
-gmxp_res = process_commands(['getmasterxpub'])
-assert('error' in gmxp_res)
-assert(gmxp_res['error'] == 'You must specify a device type or fingerprint for all commands except enumerate')
-assert('code' in gmxp_res)
-assert(gmxp_res['code'] == -1)
-
-logging.info('Testing path and type specified')
-gmxp_res = process_commands(['-t', enum_res[0]['type'], '-d', enum_res[0]['path'], 'getmasterxpub'])
-assert(gmxp_res['xpub'] == 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH')
-
-# Test fingerprint autodetect
-logging.info('Testing fingerprint autodetect')
-gmxp_res = process_commands(['-f', enum_res[0]['fingerprint'], 'getmasterxpub'])
-assert(gmxp_res['xpub'] == 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH')
-
-# Test device type autodetect
-logging.info('Testing only device type specified')
-gmxp_res = process_commands(['-t', enum_res[0]['type'], 'getmasterxpub'])
-assert(gmxp_res['xpub'] == 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH')
-
-# Test getxpub
-# BIP 32 test vectors
-logging.info('Testing getxpub and getmasterxpub')
-with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/bip32_vectors.json'), encoding='utf-8') as f:
-    vectors = json.load(f)
-for vec in vectors:
-    # Setup with xprv
+    client = TrezorClientDebugLink(wirelink)
     device.wipe(client)
-    load_device_by_xprv(client=client, xprv=vec['xprv'], pin='', passphrase_protection=False, label='test', language='english')
+    load_device_by_mnemonic(client=client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=False, label='test') # From Trezor device tests
 
-    # Test getmasterxpub
-    gmxp_res = process_commands(dev_args + ['getmasterxpub'])
-    assert(gmxp_res['xpub'] == vec['master_xpub'])
+    class TrezorTestCase(unittest.TestCase):
+        def __init__(self, client, methodName='runTest'):
+            super(TrezorTestCase, self).__init__(methodName)
+            self.client = client
 
-    # Test the path derivs
-    for path_vec in vec['vectors']:
-        gxp_res = process_commands(dev_args + ['getxpub', path_vec['path']])
-        assert(gxp_res['xpub'] == path_vec['xpub'])
+        @staticmethod
+        def parameterize(testclass, client):
+            testloader = unittest.TestLoader()
+            testnames = testloader.getTestCaseNames(testclass)
+            suite = unittest.TestSuite()
+            for name in testnames:
+                suite.addTest(testclass(client, name))
+            return suite
 
-# signtx and getkeypool need bitcoind, so start that
-logging.info('Setting up bitcoind')
-datadir = tempfile.mkdtemp()
-bitcoind_proc = subprocess.Popen([args.bitcoind, '-regtest', '-datadir=' + datadir, '-noprinttoconsole'])
-def cleanup_bitcoind():
-    bitcoind_proc.kill()
-    shutil.rmtree(datadir)
-atexit.register(cleanup_bitcoind)
-# Wait for cookie file to be created
-while not os.path.exists(datadir + '/regtest/.cookie'):
-    time.sleep(0.5)
-# Read .cookie file to get user and pass
-with open(datadir + '/regtest/.cookie') as f:
-    userpass = f.readline().lstrip().rstrip()
-rpc = AuthServiceProxy('http://{}@127.0.0.1:18443'.format(userpass))
+    # Trezor specific getxpub test because this requires device specific thing to set xprvs
+    class TestTrezorGetxpub(TrezorTestCase):
+        def test_getxpub(self):
+            with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/bip32_vectors.json'), encoding='utf-8') as f:
+                vectors = json.load(f)
+            for vec in vectors:
+                with self.subTest(vector=vec):
+                    # Setup with xprv
+                    device.wipe(self.client)
+                    load_device_by_xprv(client=self.client, xprv=vec['xprv'], pin='', passphrase_protection=False, label='test', language='english')
 
-# Wait for bitcoind to be ready
-ready = False
-while not ready:
-    try:
-        rpc.getblockchaininfo()
-        ready = True
-    except JSONRPCException as e:
-        time.sleep(0.5)
-        pass
+                    # Test getmasterxpub
+                    gmxp_res = process_commands(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub'])
+                    self.assertEqual(gmxp_res['xpub'], vec['master_xpub'])
 
-# Setup bitcoind with no privkey wallet and some blocks
-rpc.generatetoaddress(101, rpc.getnewaddress())
-rpc.createwallet('trezor_test', True)
-wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/trezor_test'.format(userpass))
-wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(userpass))
+                    # Test the path derivs
+                    for path_vec in vec['vectors']:
+                        gxp_res = process_commands(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getxpub', path_vec['path']])
+                        self.assertEqual(gxp_res['xpub'], path_vec['xpub'])
 
-# Since this is regtest, we need to use regtest in our args
-dev_args.append('--testnet')
+    # Generic Device tests
+    suite = unittest.TestSuite()
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'trezor', 'udp:127.0.0.1:21324', '95d8f670', 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'))
+    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, 'trezor', 'udp:127.0.0.1:21324', '95d8f670', 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, 'trezor', 'udp:127.0.0.1:21324', '95d8f670', 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'))
+    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, 'trezor', 'udp:127.0.0.1:21324', '95d8f670', 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'))
+    suite.addTest(TrezorTestCase.parameterize(TestTrezorGetxpub, client))
+    return suite
 
-# Test getkeypool
-logging.info('Testing getkeypool: Importable to privkey enabled wallet')
-non_keypool_desc = process_commands(dev_args + ['getkeypool', '0', '20'])
-import_result = wpk_rpc.importmulti(non_keypool_desc)
-assert(import_result[0]['success'])
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test Trezor implementation')
+    parser.add_argument('emulator', help='Path to the Trezor emulator')
+    parser.add_argument('bitcoind', help='Path to bitcoind binary')
+    args = parser.parse_args()
 
-logging.info('Testing getkeypool: Not importable to privkey enabled wallet')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '0', '20'])
-import_result = wpk_rpc.importmulti(keypool_desc)
-assert(import_result[0]['success'] == False)
+    # Start bitcoind
+    rpc, userpass = start_bitcoind(args.bitcoind)
 
-logging.info('Testing getkeypool: Imports to non privkey enabled wallet keypool')
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/44'/1'/0'/0/{}".format(i))
-
-logging.info('Testing getkeypool: Imports to non privkey enabled wallet internal keypool')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--internal', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/44'/1'/0'/1/{}".format(i))
-
-logging.info('Testing getkeypool: --sh_wpkh uses correct derivation path')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/49'/1'/0'/0/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/49'/1'/0'/1/{}".format(i))
-
-logging.info('Testing getkeypool: --wpkh uses correct derivation path')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--wpkh', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/84'/1'/0'/0/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--wpkh', '--internal', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/84'/1'/0'/1/{}".format(i))
-
-logging.info('Testing getkeypool: --account uses correct derivation path')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--account', '3', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/49'/1'/3'/0/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '--account', '3', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/49'/1'/3'/1/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--wpkh', '--account', '3', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/84'/1'/3'/0/{}".format(i))
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--wpkh', '--internal', '--account', '3', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getrawchangeaddress())
-    assert(addr_info['hdkeypath'] == "m/84'/1'/3'/1/{}".format(i))
-
-logging.info('Testing getkeypool: --path uses correct derivation path')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--path', 'm/0h/0h/4h/*', '0', '20'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-for i in range(0, 21):
-    addr_info = wrpc.getaddressinfo(wrpc.getnewaddress())
-    assert(addr_info['hdkeypath'] == "m/0'/0'/4'/{}".format(i))
-
-logging.info('Testing getkeypool: check --path parse failures')
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--path', '/0h/0h/4h/*', '0', '20'])
-assert(keypool_desc['error'] == 'Path must start with m/')
-assert(keypool_desc['code'] == -7)
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--path', 'm/0h/0h/4h/', '0', '20'])
-assert(keypool_desc['error'] == 'Path must end with /*')
-assert(keypool_desc['code'] == -7)
-
-# Test displayaddress
-logging.info('Testing displayaddress legacy')
-process_commands(dev_args + ['displayaddress', 'm/44h/1h/0h/0/0'])
-logging.info('Testing displayaddress p2sh segwit')
-process_commands(dev_args + ['displayaddress', '--sh_wpkh', 'm/49h/1h/0h/0/0'])
-logging.info('Testing displayaddress native segwit')
-process_commands(dev_args + ['displayaddress', '--wpkh', 'm/84h/1h/0h/0/0'])
-
-# Test signtx
-logging.info('Testing signtx')
-# Import some keys to the watch only wallet and send coins to them
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '30', '40'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-keypool_desc = process_commands(dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '30', '40'])
-import_result = wrpc.importmulti(keypool_desc)
-assert(import_result[0]['success'])
-sh_wpkh_addr = wrpc.getnewaddress('', 'p2sh-segwit')
-wpkh_addr = wrpc.getnewaddress('', 'bech32')
-pkh_addr = wrpc.getnewaddress('', 'legacy')
-wrpc.importaddress(wpkh_addr)
-wrpc.importaddress(pkh_addr)
-wpk_rpc.sendtoaddress(sh_wpkh_addr, 10)
-wpk_rpc.sendtoaddress(wpkh_addr, 10)
-wpk_rpc.sendtoaddress(pkh_addr, 10)
-wpk_rpc.generatetoaddress(6, wpk_rpc.getnewaddress())
-
-# Create a psbt spending the above
-psbt = wrpc.walletcreatefundedpsbt([], [{wpk_rpc.getnewaddress():10}], 0, {'includeWatching': True, 'subtractFeeFromOutputs': [0]}, True)
-sign_res = process_commands(dev_args + ['signtx', psbt['psbt']])
-finalize_res = wrpc.finalizepsbt(sign_res['psbt'])
-assert(finalize_res['complete'])
-wrpc.sendrawtransaction(finalize_res['hex'])
-
-# Done
-logging.info('PASS')
+    suite = trezor_test_suite(args.emulator, rpc, userpass)
+    unittest.TextTestRunner().run(suite)


### PR DESCRIPTION
Changes the tests to use Python's unittest framework. This cuts down on duplication and allows for tests to be run in parallel and all tests to be run when one fails.

Also fixes some bugs that were uncovered in the process of doing this.