### PR TITLE
Implement displayaddress for Coldcard and Digital BitBox and make it return the address displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Please also see [docs](docs/) for additional information about each device.
 | Arbitrary witnessScript Inputs | Yes | No | Yes | No | N/A |
 | Non-wallet inputs | Yes | Yes | Yes | Yes | Yes |
 | Mixed Segwit and Non-Segwit Inputs | No | Yes | Yes | Partial | Yes |
-| Display on device screen | Yes | Yes | N/A | No | No |
+| Display on device screen | Yes | Yes | N/A | No | Yes |
 
 ## Using with Bitcoin Core
 

--- a/README.md
+++ b/README.md
@@ -48,28 +48,30 @@ Please also see [docs](docs/) for additional information about each device.
 | Feature \ Device | Ledger Nano S | Trezor One | Digital BitBox | KeepKey | Coldcard |
 |:---:|:---:|:---:|:---:|:---:|:---:|
 | Support Planned | Yes | Yes | Yes | Yes | Yes |
-| Implemented | Partial | Partial | Partial | Partial | Partial |
+| Implemented | Yes | Partial | Yes | Partial | Partial |
 | xpub retrieval | Yes | Yes | Yes | Yes | Yes |
-| Message Signing | Yes | No | No | No | No |
-| Device Setup | No | No | No | No | No |
-| Device Recovery | No | No | No | No | No |
-| Device Reset | No | No | No | No | No |
+| Message Signing | Yes | No | Yes | No | No |
+| Device Setup | N/A | Yes | Yes | Yes | N/A |
+| Device Wipe | N/A | Yes | Yes | Yes | N/A |
+| Device Recovery | N/A | Yes | N/A | Yes | N/A |
+| Device Backup | N/A | N/A | Yes | N/A | Yes |
 | P2PKH Inputs | Yes | Yes | Yes | Partial | Yes |
 | P2SH-P2WPKH Inputs | Yes | Yes | Yes | Partial | Yes |
 | P2WPKH Inputs | Yes | Yes | Yes | Partial | Yes |
-| P2SH Multisig Inputs | Yes | No | Yes | No | ?? |
-| P2SH-P2WSH Multisig Inputs | Yes | No | Yes | No | ?? |
-| P2WSH Multisig Inputs | Yes | No | Yes | No | ?? |
-| Bare Multisig Inputs | Yes | No | Yes | No | ?? |
-| Aribtrary scriptPubKey Inputs | Yes | No | Yes | No | ?? |
-| Aribtrary redeemScript Inputs | Yes | No | Yes | No | ?? |
-| Arbitrary witnessScript Inputs | Yes | No | Yes | No | ?? |
+| P2SH Multisig Inputs | Yes | No | Yes | No | N/A |
+| P2SH-P2WSH Multisig Inputs | Yes | No | Yes | No | N/A |
+| P2WSH Multisig Inputs | Yes | No | Yes | No | N/A |
+| Bare Multisig Inputs | Yes | No | Yes | No | N/A |
+| Aribtrary scriptPubKey Inputs | Yes | No | Yes | No | N/A |
+| Aribtrary redeemScript Inputs | Yes | No | Yes | No | N/A |
+| Arbitrary witnessScript Inputs | Yes | No | Yes | No | N/A |
 | Non-wallet inputs | Yes | Yes | Yes | Yes | Yes |
-| Mixed Segwit and Non-Segwit Inputs | No | Yes | Yes | ?? | ?? |
+| Mixed Segwit and Non-Segwit Inputs | No | Yes | Yes | Partial | Yes |
+| Display on device screen | Yes | Yes | N/A | No | No |
 
 ## Using with Bitcoin Core
 
-See (Using Bitcoin Core with Hardware Wallets)[docs/bitcoin-core-usage.md].
+See [Using Bitcoin Core with Hardware Wallets](docs/bitcoin-core-usage.md).
 
 ## License
 

--- a/docs/coldcard.md
+++ b/docs/coldcard.md
@@ -11,6 +11,7 @@ Current implemented commands are:
 - `wipe`
 - `restore`
 - `backup`
+- `displayaddress`
 
 ## Notes on `setup`, `wipe`, and `restore`
 

--- a/docs/coldcard.md
+++ b/docs/coldcard.md
@@ -5,5 +5,21 @@ The ColdCard is partially supported by HWI
 Current implemented commands are:
 
 * `getmasterxpub`
-* `signtx`
+* `signtx` (only single key)
 * `getxpub`
+- `setup`
+- `wipe`
+- `restore`
+- `backup`
+
+## Notes on `setup`, `wipe`, and `restore`
+
+The Coldcard does not allow you to setup, wipe, or restore the device via software. That is done on the device itself. The implementation here is just to let users know those commands do not work.
+
+## Note on `backup`
+
+The `backup` command will create a backup file in the current working directory. This file is protected by the passphrase shown on the Coldcard during the backup process.
+
+## Caveat for `signtx`
+
+The Coldcard firmware only supports signing single key transactions. It cannot sign multisig or arbitrary scripts yet.

--- a/docs/digitalbitbox.md
+++ b/docs/digitalbitbox.md
@@ -11,6 +11,7 @@ Current implemented commands are:
 - `wipe`
 - `restore`
 - `backup`
+- `displayaddress`
 
 ## Usage Notes
 
@@ -27,3 +28,7 @@ The Digital BitBox requires that one of the levels in the derivation path is har
 ## Note on `restore`
 
 The Digital BitBox does not allow users to restore a backup or seed via software.
+
+## Note on `displayaddress`
+
+The Digital BitBox does not have a screen to display an address on, so the implementation just raises an error stating this.

--- a/docs/digitalbitbox.md
+++ b/docs/digitalbitbox.md
@@ -1,12 +1,16 @@
 # Digital BitBox
 
-The Digital BitBox is partially supported by HWI
+The Digital BitBox is supported by HWI
 
 Current implemented commands are:
 
 * `getmasterxpub`
 * `signtx`
 * `getxpub` (with some caveats)
+- `setup`
+- `wipe`
+- `restore`
+- `backup`
 
 ## Usage Notes
 
@@ -19,3 +23,7 @@ You must specify your Digital BitBox password using the `-p` option. E.g.
 ## `getxpub` Caveats
 
 The Digital BitBox requires that one of the levels in the derivation path is hardened.
+
+## Note on `restore`
+
+The Digital BitBox does not allow users to restore a backup or seed via software.

--- a/docs/keepkey.md
+++ b/docs/keepkey.md
@@ -6,7 +6,15 @@ Current implemented commands are:
 
 * `getmasterxpub`
 * `getxpub`
+- `setup`
+- `wipe`
+- `restore`
+- `backup`
 
 ## `signtx` Notes
 
 `signtx` has an implementation but has not been tested to be working. Use at your own risk.
+
+## Note on `backup`
+
+Once the device is backed up at setup, the seed words will not be shown again to be backed up. The implementation here lets users know that `backup` does not work.

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -1,6 +1,6 @@
 # Ledger Nano S
 
-The Ledger Nano S is partially supported by HWI.
+The Ledger Nano S is supported by HWI.
 
 Currently implemented commands:
 
@@ -8,9 +8,18 @@ Currently implemented commands:
 * `signtx` (with some caveats)
 * `getxpub`
 * `signmessage`
+- `displayaddress`
+- `setup`
+- `wipe`
+- `restore`
+- `backup`
 
 ## `signtx` Caveats
 
 Due to device limitiations, not all kinds of transactions can be signed by a Ledger. 
 
 * Transactions containing both segwit and non-segwit inputs are not entirely supported; only the segwit inputs will be signed in this case.
+
+## Notes on `setup`, `wipe`, `restore`, and `backup`
+
+The Ledger does not allow you to setup, wipe, restore, or backup it via software. That is done on the device itself. The implementation here is just to let users know those commands do not work.

--- a/docs/trezor.md
+++ b/docs/trezor.md
@@ -7,6 +7,11 @@ Current implemented commands are:
 * `getmasterxpub`
 * `signtx` (with some caveats)
 * `getxpub`
+- `displayaddress`
+- `setup`
+- `wipe`
+- `restore`
+- `backup`
 
 ## `signtx` Caveats
 
@@ -14,3 +19,7 @@ Due to the limitations of the Trezor and of the lack of documentation, some tran
 
 * The current implementation does not support signing Multisig inputs
 * Transactions with arbitrary input scripts (scriptPubKey, redeemScript, or witnessScript) and arbitrary output scripts cannot be signed
+
+## Note on `backup`
+
+Once the device is backed up at setup, the seed words will not be shown again to be backed up. The implementation here lets users know that `backup` does not work.

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -224,6 +224,14 @@ def restore_device(args, client):
     except ValueError as e:
         return {'error': str(e), 'code': BAD_ARGUMENT}
 
+def backup_device(args, client):
+    try:
+        return client.backup_device(args.label, args.backup_passphrase)
+    except UnavailableActionError as e:
+        return {'error': str(e), 'code': UNAVAILABLE_ACTION}
+    except ValueError as e:
+        return {'error': str(e), 'code': BAD_ARGUMENT}
+
 def process_commands(args):
     parser = argparse.ArgumentParser(description='Access and send commands to a hardware wallet device. Responses are in JSON format')
     parser.add_argument('--device-path', '-d', help='Specify the device path of the device to connect to')
@@ -285,6 +293,11 @@ def process_commands(args):
     restore_parser = subparsers.add_parser('restore', help='Initiate the device restoring process')
     restore_parser.add_argument('--label', '-l', help='The name to give to the device', default='')
     restore_parser.set_defaults(func=restore_device)
+
+    backup_parser = subparsers.add_parser('backup', help='Initiate the device backup creation process')
+    backup_parser.add_argument('--label', '-l', help='The name to give to the device', default='')
+    backup_parser.add_argument('--backup_passphrase', '-b', help='The passphrase to use for the backup, if applicable', default='')
+    backup_parser.set_defaults(func=backup_device)
 
     args = parser.parse_args(args)
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -208,6 +208,12 @@ def setup_device(args, client):
     except ValueError as e:
         return {'error': str(e), 'code': BAD_ARGUMENT}
 
+def wipe_device(args, client):
+    try:
+        return client.wipe_device()
+    except UnavailableActionError as e:
+        return {'error': str(e), 'code': UNAVAILABLE_ACTION}
+
 def process_commands(args):
     parser = argparse.ArgumentParser(description='Access and send commands to a hardware wallet device. Responses are in JSON format')
     parser.add_argument('--device-path', '-d', help='Specify the device path of the device to connect to')
@@ -262,6 +268,9 @@ def process_commands(args):
     setupdev_parser.add_argument('--label', '-l', help='The name to give to the device', default='')
     setupdev_parser.add_argument('--backup_passphrase', '-b', help='The passphrase to use for the backup, if applicable', default='')
     setupdev_parser.set_defaults(func=setup_device)
+
+    wipedev_parser = subparsers.add_parser('wipe', help='Wipe a device')
+    wipedev_parser.set_defaults(func=wipe_device)
 
     args = parser.parse_args(args)
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -214,6 +214,16 @@ def wipe_device(args, client):
     except UnavailableActionError as e:
         return {'error': str(e), 'code': UNAVAILABLE_ACTION}
 
+def restore_device(args, client):
+    try:
+        return client.restore_device(args.label)
+    except UnavailableActionError as e:
+        return {'error': str(e), 'code': UNAVAILABLE_ACTION}
+    except DeviceAlreadyInitError as e:
+        return {'error': str(e), 'code': DEVICE_ALREADY_INIT}
+    except ValueError as e:
+        return {'error': str(e), 'code': BAD_ARGUMENT}
+
 def process_commands(args):
     parser = argparse.ArgumentParser(description='Access and send commands to a hardware wallet device. Responses are in JSON format')
     parser.add_argument('--device-path', '-d', help='Specify the device path of the device to connect to')
@@ -271,6 +281,10 @@ def process_commands(args):
 
     wipedev_parser = subparsers.add_parser('wipe', help='Wipe a device')
     wipedev_parser.set_defaults(func=wipe_device)
+
+    restore_parser = subparsers.add_parser('restore', help='Initiate the device restoring process')
+    restore_parser.add_argument('--label', '-l', help='The name to give to the device', default='')
+    restore_parser.set_defaults(func=restore_device)
 
     args = parser.parse_args(args)
 

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -3,7 +3,7 @@
 from ..hwwclient import HardwareWalletClient, UnavailableActionError
 from ckcc.client import ColdcardDevice, COINKITE_VID, CKCC_PID
 from ckcc.protocol import CCProtocolPacker
-from ckcc.constants import MAX_BLK_LEN
+from ckcc.constants import MAX_BLK_LEN, AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH
 from ..base58 import xpub_main_2_test, get_xpub_fingerprint_hex
 from hashlib import sha256
 
@@ -98,7 +98,16 @@ class ColdcardClient(HardwareWalletClient):
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
-        raise NotImplementedError('The Coldcard does not currently implement displayaddress')
+        keypath = keypath.replace('h', '\'')
+        keypath = keypath.replace('H', '\'')
+
+        if p2sh_p2wpkh:
+            format = AF_P2WPKH_P2SH
+        elif bech32:
+            format = AF_P2WPKH
+        else:
+            format = AF_CLASSIC
+        self.device.send_recv(CCProtocolPacker.show_address(keypath, format), timeout=None)
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -107,7 +107,8 @@ class ColdcardClient(HardwareWalletClient):
             format = AF_P2WPKH
         else:
             format = AF_CLASSIC
-        self.device.send_recv(CCProtocolPacker.show_address(keypath, format), timeout=None)
+        address = self.device.send_recv(CCProtocolPacker.show_address(keypath, format), timeout=None)
+        return {'address': address}
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -108,6 +108,10 @@ class ColdcardClient(HardwareWalletClient):
     def wipe_device(self):
         raise NotImplementedError('The Coldcard does not currently implement wipe')
 
+    # Restore device from mnemonic or xprv
+    def restore_device(self, label=''):
+        raise NotImplementedError('The Coldcard does not implement device restoring')
+
     # Close the device
     def close(self):
         self.device.close()

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -112,6 +112,10 @@ class ColdcardClient(HardwareWalletClient):
     def restore_device(self, label=''):
         raise NotImplementedError('The Coldcard does not implement device restoring')
 
+    # Begin backup process
+    def backup_device(self, label='', passphrase=''):
+        raise NotImplementedError('The Coldcard does not implement this method')
+
     # Close the device
     def close(self):
         self.device.close()

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -101,7 +101,7 @@ class ColdcardClient(HardwareWalletClient):
         raise NotImplementedError('The Coldcard does not currently implement displayaddress')
 
     # Setup a new device
-    def setup_device(self):
+    def setup_device(self, label='', passphrase=''):
         raise NotImplementedError('The Coldcard does not currently implement setup')
 
     # Wipe this device

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -360,7 +360,7 @@ class DigitalbitboxClient(HardwareWalletClient):
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
-        raise NotImplementedError('The DigitalBitbox does not currently implement displayaddress')
+        raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -362,6 +362,10 @@ class DigitalbitboxClient(HardwareWalletClient):
     def wipe_device(self):
         raise NotImplementedError('The DigitalBitbox does not currently implement wipe')
 
+    # Restore device from mnemonic or xprv
+    def restore_device(self, label=''):
+        raise NotImplementedError('The Digital Bitbox does not implement device restoring')
+
     # Close the device
     def close(self):
         self.device.close()

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -355,7 +355,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         raise NotImplementedError('The DigitalBitbox does not currently implement displayaddress')
 
     # Setup a new device
-    def setup_device(self):
+    def setup_device(self, label='', passphrase=''):
         raise NotImplementedError('The DigitalBitbox does not currently implement setup')
 
     # Wipe this device

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -9,8 +9,9 @@ import hashlib
 import os
 import binascii
 import logging
+import time
 
-from ..hwwclient import HardwareWalletClient, NoPasswordError
+from ..hwwclient import HardwareWalletClient, NoPasswordError, UnavailableActionError
 from ..serializations import CTransaction, PSBT, hash256, hash160, ser_sig_der, ser_sig_compact, ser_compact_size
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 
@@ -140,6 +141,13 @@ def send_encrypt(msg, password, device):
     except Exception as e:
         reply = {'error':'Exception caught while sending encrypted message to DigitalBitbox ' + str(e)}
     return reply
+
+def stretch_backup_key(password):
+    key = hashlib.pbkdf2_hmac('sha512', password.encode(), b'Digital Bitbox', 20480)
+    return binascii.hexlify(key).decode()
+
+def format_backup_filename(name):
+    return '{}-{}.pdf'.format(name, time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime()))
 
 # This class extends the HardwareWalletClient for Digital Bitbox specific things
 class DigitalbitboxClient(HardwareWalletClient):
@@ -356,19 +364,48 @@ class DigitalbitboxClient(HardwareWalletClient):
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):
-        raise NotImplementedError('The DigitalBitbox does not currently implement setup')
+        # Make sure this is not initialized
+        reply = send_encrypt('{"device" : "info"}', self.password, self.device)
+        if 'error' not in reply or ('error' in reply and reply['error']['code'] != 101):
+            raise DeviceAlreadyInitError('Device is already initialized. Use wipe first and try again')
+
+        # Need a wallet name and backup passphrase
+        if not label or not passphrase:
+            raise ValueError('THe label and backup passphrase for a new Digital Bitbox wallet must be specified and cannot be empty')
+
+        # Set password
+        to_send = {'password': self.password}
+        reply = send_plain(json.dumps(to_send).encode(), self.device)
+
+        # Now make the wallet
+        key = stretch_backup_key(passphrase)
+        backup_filename = format_backup_filename(label)
+        to_send = {'seed': {'source': 'create', 'key': key, 'filename': backup_filename}}
+        reply = send_encrypt(json.dumps(to_send).encode(), self.password, self.device)
+        if 'error' in reply:
+            return {'success': False, 'error': reply['error']['message']}
+        return {'success': True}
 
     # Wipe this device
     def wipe_device(self):
-        raise NotImplementedError('The DigitalBitbox does not currently implement wipe')
+        reply = send_encrypt('{"reset" : "__ERASE__"}', self.password, self.device)
+        if 'error' in reply:
+            return {'success': False, 'error': reply['error']['message']}
+        return {'success': True}
 
     # Restore device from mnemonic or xprv
     def restore_device(self, label=''):
-        raise NotImplementedError('The Digital Bitbox does not implement device restoring')
+        raise UnavailableActionError('The Digital Bitbox does not support restoring via software')
 
     # Begin backup process
     def backup_device(self, label='', passphrase=''):
-        raise NotImplementedError('The Digital BitBox does not implement this method')
+        key = stretch_backup_key(passphrase)
+        backup_filename = format_backup_filename(label)
+        to_send = {'backup': {'source': 'HWW', 'key': key, 'filename': backup_filename}}
+        reply = send_encrypt(json.dumps(to_send).encode(), self.password, self.device)
+        if 'error' in reply:
+            return {'success': False, 'error': reply['error']['message']}
+        return {'success': True}
 
     # Close the device
     def close(self):

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -366,6 +366,10 @@ class DigitalbitboxClient(HardwareWalletClient):
     def restore_device(self, label=''):
         raise NotImplementedError('The Digital Bitbox does not implement device restoring')
 
+    # Begin backup process
+    def backup_device(self, label='', passphrase=''):
+        raise NotImplementedError('The Digital BitBox does not implement this method')
+
     # Close the device
     def close(self):
         self.device.close()

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -424,8 +424,14 @@ def enumerate(password=''):
 
             try:
                 client = DigitalbitboxClient(path, password)
-                master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-                d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+
+                # Check initialized
+                reply = send_encrypt('{"device" : "info"}', password, client.device)
+                if 'error' in reply and reply['error']['code'] == 101:
+                    d_data['error'] = 'Not initialized'
+                else:
+                    master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
+                    d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
                 client.close()
             except Exception as e:
                 d_data['error'] = "Could not open client or get fingerprint information: " + str(e)

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -180,7 +180,7 @@ class KeepkeyClient(HardwareWalletClient):
         raise NotImplementedError('The KeepKey does not currently implement displayaddress')
 
     # Setup a new device
-    def setup_device(self):
+    def setup_device(self, label='', passphrase=''):
         raise NotImplementedError('The KeepKey does not currently implement setup')
 
     # Wipe this device

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -219,8 +219,11 @@ def enumerate(password=''):
 
         try:
             client = KeepkeyClient(path, password)
-            master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-            d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+            if client.client.features.initialized:
+                master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
+                d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+            else:
+                d_data['error'] = 'Not initialized'
             client.close()
         except Exception as e:
             d_data['error'] = "Could not open client or get fingerprint information: " + str(e)

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -1,6 +1,6 @@
 # KeepKey interaction script
 
-from ..hwwclient import HardwareWalletClient
+from ..hwwclient import HardwareWalletClient, UnavailableActionError
 from keepkeylib.transport_hid import HidTransport
 from keepkeylib.client import KeepKeyClient as KeepKey
 from keepkeylib import tools
@@ -11,6 +11,7 @@ from ..serializations import ser_uint256, uint256_from_str
 
 import binascii
 import json
+import os
 
 KEEPKEY_VENDOR_ID = 0x2B24
 KEEPKEY_DEVICE_ID = 0x0001
@@ -59,6 +60,9 @@ class KeepkeyClient(HardwareWalletClient):
         # if it wasn't able to find a client, throw an error
         if not self.client:
             raise IOError("no Device")
+
+        self.password = password
+        os.environ['PASSPHRASE'] = password
 
     # Must return a dict with the xpub
     # Retrieves the public key at the specified BIP 32 derivation path
@@ -181,19 +185,24 @@ class KeepkeyClient(HardwareWalletClient):
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):
-        raise NotImplementedError('The KeepKey does not currently implement setup')
+        if self.client.features.initialized:
+            raise DeviceAlreadyInitError('Device is already initialized. Use wipe first and try again')
+        self.client.reset_device(False, 256, bool(self.password), True, label, 'english')
+        return {'success': True}
 
     # Wipe this device
     def wipe_device(self):
-        raise NotImplementedError('The KeepKey does not currently implement wipe')
+        self.client.wipe_device()
+        return {'success': True}
 
     # Restore device from mnemonic or xprv
     def restore_device(self, label=''):
-        raise NotImplementedError('The Keepkey does not implement device restoring')
+        self.client.recovery_device(False, 24, bool(self.password), True, label, 'english')
+        return {'success': True}
 
     # Begin backup process
     def backup_device(self, label='', passphrase=''):
-        raise NotImplementedError('The Keepkey does not implement this method')
+        raise UnavailableActionError('The Keepkey does not support creating a backup via software')
 
     # Close the device
     def close(self):

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -187,6 +187,10 @@ class KeepkeyClient(HardwareWalletClient):
     def wipe_device(self):
         raise NotImplementedError('The KeepKey does not currently implement wipe')
 
+    # Restore device from mnemonic or xprv
+    def restore_device(self, label=''):
+        raise NotImplementedError('The Keepkey does not implement device restoring')
+
     # Close the device
     def close(self):
         self.client.close()

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -191,6 +191,10 @@ class KeepkeyClient(HardwareWalletClient):
     def restore_device(self, label=''):
         raise NotImplementedError('The Keepkey does not implement device restoring')
 
+    # Begin backup process
+    def backup_device(self, label='', passphrase=''):
+        raise NotImplementedError('The Keepkey does not implement this method')
+
     # Close the device
     def close(self):
         self.client.close()

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -245,7 +245,8 @@ class LedgerClient(HardwareWalletClient):
         return {"signature":base64.b64encode(sig).decode('utf-8')}
 
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
-        self.app.getWalletPublicKey(keypath[2:], True, (p2sh_p2wpkh or bech32), bech32)
+        output = self.app.getWalletPublicKey(keypath[2:], True, (p2sh_p2wpkh or bech32), bech32)
+        return {'address': output['address'][12:-2]} # HACK: A bug in getWalletPublicKey results in the address being returned as the string "bytearray(b'<address>')". This extracts the actual address to work around this.
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -259,6 +259,10 @@ class LedgerClient(HardwareWalletClient):
     def restore_device(self, label=''):
         raise NotImplementedError('The Ledger Nano S does not implement device restoring')
 
+    # Begin backup process
+    def backup_device(self, label='', passphrase=''):
+        raise NotImplementedError('The Ledger Nano S does not implement this method')
+
     # Close the device
     def close(self):
         self.dongle.close()

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -255,6 +255,10 @@ class LedgerClient(HardwareWalletClient):
     def wipe_device(self):
         raise NotImplementedError('The Ledger Nano S does not support wiping via software')
 
+    # Restore device from mnemonic or xprv
+    def restore_device(self, label=''):
+        raise NotImplementedError('The Ledger Nano S does not implement device restoring')
+
     # Close the device
     def close(self):
         self.dongle.close()

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -248,7 +248,7 @@ class LedgerClient(HardwareWalletClient):
         self.app.getWalletPublicKey(keypath[2:], True, (p2sh_p2wpkh or bech32), bech32)
 
     # Setup a new device
-    def setup_device(self):
+    def setup_device(self, label='', passphrase=''):
         raise NotImplementedError('The Ledger Nano S does not support software setup')
 
     # Wipe this device

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -1,6 +1,6 @@
 # Ledger interaction script
 
-from ..hwwclient import HardwareWalletClient
+from ..hwwclient import HardwareWalletClient, UnavailableActionError
 from btchip.btchip import *
 from btchip.btchipUtils import *
 import base64
@@ -249,19 +249,19 @@ class LedgerClient(HardwareWalletClient):
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):
-        raise NotImplementedError('The Ledger Nano S does not support software setup')
+        raise UnavailableActionError('The Ledger Nano S does not support software setup')
 
     # Wipe this device
     def wipe_device(self):
-        raise NotImplementedError('The Ledger Nano S does not support wiping via software')
+        raise UnavailableActionError('The Ledger Nano S does not support wiping via software')
 
     # Restore device from mnemonic or xprv
     def restore_device(self, label=''):
-        raise NotImplementedError('The Ledger Nano S does not implement device restoring')
+        raise UnavailableActionError('The Ledger Nano S does not support restoring via software')
 
     # Begin backup process
     def backup_device(self, label='', passphrase=''):
-        raise NotImplementedError('The Ledger Nano S does not implement this method')
+        raise UnavailableActionError('The Ledger Nano S does not support creating a backup via software')
 
     # Close the device
     def close(self):

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -183,13 +183,14 @@ class TrezorClient(HardwareWalletClient):
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
         expanded_path = tools.parse_path(keypath)
-        output = btc.get_address(
+        address = btc.get_address(
             self.client,
             "Testnet" if self.is_testnet else "Bitcoin",
             expanded_path,
             show_display=True,
             script_type=proto.InputScriptType.SPENDWITNESS if bech32 else (proto.InputScriptType.SPENDP2SHWITNESS if p2sh_p2wpkh else proto.InputScriptType.SPENDADDRESS)
         )
+        return {'address': address}
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -182,14 +182,14 @@ class TrezorClient(HardwareWalletClient):
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
-      expanded_path = tools.parse_path(keypath)
-      output = btc.get_address(
-        self.client,
-        "Testnet" if self.is_testnet else "Bitcoin",
-        expanded_path,
-        show_display=True,
-        script_type=proto.InputScriptType.SPENDWITNESS if bech32 else (proto.InputScriptType.SPENDP2SHWITNESS if p2sh_p2wpkh else proto.InputScriptType.SPENDADDRESS)
-      )
+        expanded_path = tools.parse_path(keypath)
+        output = btc.get_address(
+            self.client,
+            "Testnet" if self.is_testnet else "Bitcoin",
+            expanded_path,
+            show_display=True,
+            script_type=proto.InputScriptType.SPENDWITNESS if bech32 else (proto.InputScriptType.SPENDP2SHWITNESS if p2sh_p2wpkh else proto.InputScriptType.SPENDADDRESS)
+        )
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -198,6 +198,10 @@ class TrezorClient(HardwareWalletClient):
     def wipe_device(self):
         raise NotImplementedError('The Trezor does not currently implement wipe')
 
+    # Restore device from mnemonic or xprv
+    def restore_device(self, label=''):
+        raise NotImplementedError('The Trezor does not implement device restoring')
+
     # Close the device
     def close(self):
         self.client.close()

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -191,7 +191,7 @@ class TrezorClient(HardwareWalletClient):
       )
 
     # Setup a new device
-    def setup_device(self):
+    def setup_device(self, label='', passphrase=''):
         raise NotImplementedError('The Trezor does not currently implement setup')
 
     # Wipe this device

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -230,8 +230,11 @@ def enumerate(password=''):
 
         try:
             client = TrezorClient(d_data['path'], password)
-            master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-            d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+            if client.client.features.initialized:
+                master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
+                d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+            else:
+                d_data['error'] = 'Not initialized'
             client.close()
         except Exception as e:
             d_data['error'] = "Could not open client or get fingerprint information: " + str(e)

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -202,6 +202,10 @@ class TrezorClient(HardwareWalletClient):
     def restore_device(self, label=''):
         raise NotImplementedError('The Trezor does not implement device restoring')
 
+    # Begin backup process
+    def backup_device(self, label='', passphrase=''):
+        raise NotImplementedError('The Trezor does not implement this method')
+
     # Close the device
     def close(self):
         self.client.close()

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -41,6 +41,10 @@ class HardwareWalletClient(object):
         raise NotImplementedError('The HardwareWalletClient base class does not '
             'implement this method')
 
+    # Restore device from mnemonic or xprv
+    def restore_device(self, label=''):
+        raise NotImplementedError('The HardwareWalletClient base class does not implement this method')
+
     # Close the device
     def close(self):
         raise NotImplementedError('The HardwareWalletClient base class does not '

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -32,7 +32,7 @@ class HardwareWalletClient(object):
             'implement this method')
 
     # Setup a new device
-    def setup_device(self):
+    def setup_device(self, label='', passphrase=''):
         raise NotImplementedError('The HardwareWalletClient base class does not '
             'implement this method')
 
@@ -47,5 +47,13 @@ class HardwareWalletClient(object):
             'implement this method')
 
 class NoPasswordError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+class UnavailableActionError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+class DeviceAlreadyInitError(Exception):
     def __init__(self,*args,**kwargs):
         Exception.__init__(self,*args,**kwargs)

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -45,6 +45,10 @@ class HardwareWalletClient(object):
     def restore_device(self, label=''):
         raise NotImplementedError('The HardwareWalletClient base class does not implement this method')
 
+    # Begin backup process
+    def backup_device(self, label='', passphrase=''):
+        raise NotImplementedError('The HardwareWalletClient base class does not implement this method')
+
     # Close the device
     def close(self):
         raise NotImplementedError('The HardwareWalletClient base class does not '

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -10,7 +10,7 @@ import unittest
 from hwilib.commands import process_commands
 from ckcc.protocol import CCProtocolPacker
 from ckcc.client import ColdcardDevice
-from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestGetKeypool, TestSignTx
+from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignTx
 
 def coldcard_test_suite(simulator, rpc, userpass):
     # Start the Coldcard simulator
@@ -48,6 +48,7 @@ def coldcard_test_suite(simulator, rpc, userpass):
     suite.addTest(DeviceTestCase.parameterize(TestColdcardSetupWipe, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', ''))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
+    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
     # HACK: Skip this in headless simulator because it requires user input
     if not simulator.endswith('headless.py'):
         suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -27,8 +27,25 @@ def coldcard_test_suite(simulator, rpc, userpass):
         resp = dev.send_recv(CCProtocolPacker.logout())
     atexit.register(cleanup_simulator)
 
+    # Coldcard specific setup and wipe tests
+    class TestColdcardSetupWipe(DeviceTestCase):
+        def test_setup(self):
+            result = process_commands(self.dev_args + ['setup'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Coldcard does not support software setup')
+            self.assertEqual(result['code'], -9)
+
+        def test_wipe(self):
+            result = process_commands(self.dev_args + ['wipe'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Coldcard does not support wiping via software')
+            self.assertEqual(result['code'], -9)
+
     # Generic device tests
     suite = unittest.TestSuite()
+    suite.addTest(DeviceTestCase.parameterize(TestColdcardSetupWipe, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', ''))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
     # HACK: Skip this in headless simulator because it requires user input


### PR DESCRIPTION
Implements `displayaddress` for the Coldcard and Digital BitBox. The BitBox doesn't have a screen, so the implementation is just a message saying the `displayaddress` cannot be used with it.

Also changes displayaddress to return the address that was being displayed rather than `null`,

Builds on top of #82 as this needs the documentation update and the `UnavailableActionError` introduced there.