### PR TITLE
decode bytes to string before returning a dbb signmessage signature

### DIFF
--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -348,7 +348,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         compact_sig = ser_sig_compact(r, s, recid)
         logging.debug(binascii.hexlify(compact_sig))
 
-        return {"signature":base64.b64encode(compact_sig)}
+        return {"signature":base64.b64encode(compact_sig).decode('utf-8')}
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):


### PR DESCRIPTION
Lightly tested

Before :

```
$ ./hwi.py --testnet --password testnet --device-path 0003:0009:00 --device-type digitalbitbox signmessage "123" 'm/44h/1h/0h/0/0'
Touch the device for 3 seconds to sign. Touch briefly to cancel
Traceback (most recent call last):
  File "./hwi.py", line 12, in <module>
    print(json.dumps(result))
  File "/usr/lib/python3.5/json/__init__.py", line 230, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.5/json/encoder.py", line 198, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.5/json/encoder.py", line 256, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.5/json/encoder.py", line 179, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: b'HzKAyt92Xrb5AczMpAlkJhmeFhF5EEdkyQ4guqXgI/V3ehtx2OPF73/BgHLtmoaa8WxMj2IhowGA3YY3gHO4AXk=' is not JSON serializable
```

After :

```
$ ./hwi.py --testnet --password testnet --device-path 0003:0009:00 --device-type digitalbitbox signmessage "123" 'm/44h/1h/0h/0/0'
Touch the device for 3 seconds to sign. Touch briefly to cancel
{"signature": "HzKAyt92Xrb5AczMpAlkJhmeFhF5EEdkyQ4guqXgI/V3ehtx2OPF73/BgHLtmoaa8WxMj2IhowGA3YY3gHO4AXk="}
```

```
bitcoin-cli -regtest verifymessage ms7QGGjaBRptLurARyWaiJkmL6sQfQejJo 'HzKAyt92Xrb5AczMpAlkJhmeFhF5EEdkyQ4guqXgI/V3ehtx2OPF73/BgHLtmoaa8WxMj2IhowGA3YY3gHO4AXk=' 123
true
```