### PR TITLE
Implement signmessage, displayaddress, and signtx for keepkey and mark its implementation as complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,26 +49,26 @@ Please also see [docs](docs/) for additional information about each device.
 | Feature \ Device | Ledger Nano S | Trezor One | Digital BitBox | KeepKey | Coldcard |
 |:---:|:---:|:---:|:---:|:---:|:---:|
 | Support Planned | Yes | Yes | Yes | Yes | Yes |
-| Implemented | Yes | Yes | Yes | Partial | Yes |
+| Implemented | Yes | Yes | Yes | Yes | Yes |
 | xpub retrieval | Yes | Yes | Yes | Yes | Yes |
-| Message Signing | Yes | Yes | Yes | No | Yes |
+| Message Signing | Yes | Yes | Yes | Yes | Yes |
 | Device Setup | N/A | Yes | Yes | Yes | N/A |
 | Device Wipe | N/A | Yes | Yes | Yes | N/A |
 | Device Recovery | N/A | Yes | N/A | Yes | N/A |
 | Device Backup | N/A | N/A | Yes | N/A | Yes |
-| P2PKH Inputs | Yes | Yes | Yes | Partial | Yes |
-| P2SH-P2WPKH Inputs | Yes | Yes | Yes | Partial | Yes |
-| P2WPKH Inputs | Yes | Yes | Yes | Partial | Yes |
-| P2SH Multisig Inputs | Yes | Yes | Yes | No | N/A |
+| P2PKH Inputs | Yes | Yes | Yes | Yes | Yes |
+| P2SH-P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes |
+| P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes |
+| P2SH Multisig Inputs | Yes | Yes | Yes | Yes | N/A |
 | P2SH-P2WSH Multisig Inputs | Yes | No | Yes | No | N/A |
-| P2WSH Multisig Inputs | Yes | Yes | Yes | No | N/A |
-| Bare Multisig Inputs | Yes | N/A | Yes | No | N/A |
-| Aribtrary scriptPubKey Inputs | Yes | N/A | Yes | No | N/A |
-| Aribtrary redeemScript Inputs | Yes | N/A | Yes | No | N/A |
-| Arbitrary witnessScript Inputs | Yes | N/A | Yes | No | N/A |
+| P2WSH Multisig Inputs | Yes | No | Yes | Yes | N/A |
+| Bare Multisig Inputs | Yes | N/A | Yes | N/A | N/A |
+| Aribtrary scriptPubKey Inputs | Yes | N/A | Yes | N/A | N/A |
+| Aribtrary redeemScript Inputs | Yes | N/A | Yes | N/A | N/A |
+| Arbitrary witnessScript Inputs | Yes | N/A | Yes | N/A | N/A |
 | Non-wallet inputs | Yes | Yes | Yes | Yes | Yes |
-| Mixed Segwit and Non-Segwit Inputs | No | Yes | Yes | Partial | Yes |
-| Display on device screen | Yes | Yes | N/A | No | Yes |
+| Mixed Segwit and Non-Segwit Inputs | No | Yes | Yes | Yes | Yes |
+| Display on device screen | Yes | Yes | N/A | Yes | Yes |
 
 ## Using with Bitcoin Core
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip3 install hidapi # HID API needed in general
 pip3 install trezor[hidapi] # Trezor One
 pip3 install btchip-python # Ledger Nano S
 pip3 install ecdsa # Needed for btchip-python but is not installed by it
-pip3 install keepkey # KeepKey
+pip3 install git+git://github.com/keepkey/python-keepkey.git@75b32ac2e16c8dbfb5226fa0032e38ea7baafc46#egg=keepkey # KeepKey. The tags and pypi don't have the right version yet, so lock to a specific commit from their git repo
 pip3 install ckcc-protocol[cli] # Coldcard
 pip3 install pyaes # For digitalbitbox
 ```

--- a/docs/keepkey.md
+++ b/docs/keepkey.md
@@ -10,10 +10,16 @@ Current implemented commands are:
 - `wipe`
 - `restore`
 - `backup`
+- `signtx`
+- `displayaddress`
+- `signmessage`
 
-## `signtx` Notes
+## `signtx` Caveats
 
-`signtx` has an implementation but has not been tested to be working. Use at your own risk.
+Due to the limitations of the KeepKey, some transactions cannot be signed by a KeepKey.
+
+- Multisig inputs are limited to at most n-of-15 multisigs. This is a firmware limitation.
+* Transactions with arbitrary input scripts (scriptPubKey, redeemScript, or witnessScript) and arbitrary output scripts cannot be signed. This is a firmware limitation.
 
 ## Note on `backup`
 

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -9,6 +9,7 @@ from keepkeylib.tx_api import TxApi
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 from ..serializations import ser_uint256, uint256_from_str
 
+import base64
 import binascii
 import json
 import os
@@ -177,7 +178,11 @@ class KeepkeyClient(HardwareWalletClient):
     # Must return a base64 encoded string with the signed message
     # The message can be any string
     def sign_message(self, message, keypath):
-        raise NotImplementedError('The KeepKey does not currently implement signmessage')
+        keypath = keypath.replace('h', '\'')
+        keypath = keypath.replace('H', '\'')
+        expanded_path = tools.parse_path(keypath)
+        result = self.client.sign_message('Bitcoin', expanded_path, message)
+        return {'signature': base64.b64encode(result.signature).decode('utf-8')}
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -186,7 +186,16 @@ class KeepkeyClient(HardwareWalletClient):
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
-        raise NotImplementedError('The KeepKey does not currently implement displayaddress')
+        keypath = keypath.replace('h', '\'')
+        keypath = keypath.replace('H', '\'')
+        expanded_path = tools.parse_path(keypath)
+        address = self.client.get_address(
+            "Testnet" if self.is_testnet else "Bitcoin",
+            expanded_path,
+            show_display=True,
+            script_type=proto.SPENDWITNESS if bech32 else (proto.SPENDP2SHWITNESS if p2sh_p2wpkh else proto.SPENDADDRESS)
+        )
+        return {'address': address}
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -69,7 +69,7 @@ class KeepkeyClient(HardwareWalletClient):
     def get_pubkey_at_path(self, path):
         path = path.replace('h', '\'')
         path = path.replace('H', '\'')
-        expanded_path = self.client.expand_path(path)
+        expanded_path = tools.parse_path(path)
         output = self.client.get_public_node(expanded_path)
         if self.is_testnet:
             return {'xpub':xpub_main_2_test(output.xpub)}

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -321,6 +321,9 @@ def enumerate(password=''):
             else:
                 d_data['error'] = 'Not initialized'
             client.close()
+        except TypeError as e:
+            if dev.get_path().startswith('udp:'):
+                continue
         except Exception as e:
             d_data['error'] = "Could not open client or get fingerprint information: " + str(e)
 

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,13 @@ setuptools.setup(
         'hidapi', # HID API needed in general
         'trezor>=0.11.0', # Trezor One
         'btchip-python', # Ledger Nano S
-        'keepkey', # KeepKey
+        'keepkey==6.0.1', # KeepKey
         'ckcc-protocol[cli]', # Coldcard
         'pyaes',
         'ecdsa', # Needed for Ledger but their library does not install it
+    ],
+    dependency_links=[
+        'https://github.com/keepkey/python-keepkey/tarball/75b32ac2e16c8dbfb5226fa0032e38ea7baafc46#egg=keepkey-6.0.1' # The tags don't have the right version yet, so lock to a specific commit
     ],
     python_requires='>=3',
     classifiers=[


### PR DESCRIPTION
Implements the signmessage, displayaddress, and signtx commands for the keepkey. This also completes its implementation and the documentation is updated as such.

Note that because the Keepkey is a clone of the Trezor, these implementations are copies of the Trezor ones modified slightly to work with the Keepkey library.