### PR TITLE
Ledger test

### DIFF
--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -10,6 +10,7 @@ from test_coldcard import coldcard_test_suite
 from test_device import start_bitcoind
 from test_psbt import TestPSBT
 from test_trezor import trezor_test_suite
+from test_ledger import ledger_test_suite
 
 parser = argparse.ArgumentParser(description='Setup the testing environment and run automated tests')
 trezor_group = parser.add_mutually_exclusive_group()
@@ -18,6 +19,9 @@ trezor_group.add_argument('--trezor', help='Path to Trezor emulator.', default='
 coldcard_group = parser.add_mutually_exclusive_group()
 coldcard_group.add_argument('--no_coldcard', help='Do not run Coldcard test with simulator', action='store_true')
 coldcard_group.add_argument('--coldcard', help='Path to Coldcard simulator.', default='work/firmware/unix/headless.py')
+ledger_group = parser.add_mutually_exclusive_group()
+ledger_group.add_argument('--ledger', help='Run physical Ledger Nano S/X tests.', action='store_true')
+
 parser.add_argument('--bitcoind', help='Path to bitcoind.', default='work/bitcoin/src/bitcoind')
 args = parser.parse_args()
 
@@ -26,7 +30,7 @@ suite = unittest.TestSuite()
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestSegwitAddress))
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestPSBT))
 
-if not args.no_trezor or not args.no_coldcard:
+if not args.no_trezor or not args.no_coldcard or args.ledger:
     # Start bitcoind
     rpc, userpass = start_bitcoind(args.bitcoind)
 
@@ -34,5 +38,7 @@ if not args.no_trezor:
     suite.addTest(trezor_test_suite(args.trezor, rpc, userpass))
 if not args.no_coldcard:
     suite.addTest(coldcard_test_suite(args.coldcard, rpc, userpass))
+if args.ledger:
+    suite.addTest(ledger_test_suite(rpc, userpass))
 result = unittest.TextTestRunner().run(suite)
 sys.exit(not result.wasSuccessful())

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -1,0 +1,48 @@
+#! /usr/bin/env python3
+
+import argparse
+import atexit
+import json
+import os
+import socket
+import subprocess
+import time
+import unittest
+
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignTx
+
+from hwilib.commands import process_commands
+
+def ledger_test_suite(rpc, userpass):
+    # Look for real ledger using HWI API(self-referential, but no other way)
+    enum_res = process_commands(['enumerate'])
+    path = None
+    master_xpub = None
+    fingerprint = None
+    for device in enum_res:
+        if device['type'] == 'ledger':
+            fingerprint = device['fingerprint']
+            path = device['path']
+            master_xpub = process_commands(['-f', fingerprint, 'getmasterxpub'])['xpub']
+            break
+    assert(path is not None and master_xpub is not None and fingerprint is not None)
+
+    # Generic Device tests
+    suite = unittest.TestSuite()
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
+    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
+    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
+    return suite
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test Ledger implementation')
+    parser.add_argument('bitcoind', help='Path to bitcoind binary')
+    args = parser.parse_args()
+
+    # Start bitcoind
+    rpc, userpass = start_bitcoind(args.bitcoind)
+
+    suite = ledger_test_suite(rpc, userpass)
+    unittest.TextTestRunner().run(suite)


### PR DESCRIPTION
Built on https://github.com/achow101/HWI/pull/94 to properly test for the mixed-input case.

This has to be done with a physical device since there is no simulator. It bootstraps itself by grabbing the xpub and other info using enumerate(which is kind of cheating yes but you can't initialize via software), then goes through the rest of the test normally.