### PR TITLE
Finalize implementation of keepkey and add automated tests for it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ addons:
             - cython3
             - ccache
 install:
-    - pip install pipenv pysdl2 python-bitcoinrpc
+    - pip install pipenv pysdl2 python-bitcoinrpc protobuf
     # From trezor-mcu to get the correct protobuf version
     - curl -LO "https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip"
     - unzip "protoc-3.4.0-linux-x86_64.zip" -d protoc

--- a/README.md
+++ b/README.md
@@ -49,26 +49,26 @@ Please also see [docs](docs/) for additional information about each device.
 | Feature \ Device | Ledger Nano S | Trezor One | Digital BitBox | KeepKey | Coldcard |
 |:---:|:---:|:---:|:---:|:---:|:---:|
 | Support Planned | Yes | Yes | Yes | Yes | Yes |
-| Implemented | Yes | Yes | Yes | Partial | Yes |
+| Implemented | Yes | Yes | Yes | Yes | Yes |
 | xpub retrieval | Yes | Yes | Yes | Yes | Yes |
-| Message Signing | Yes | Yes | Yes | No | Yes |
+| Message Signing | Yes | Yes | Yes | Yes | Yes |
 | Device Setup | N/A | Yes | Yes | Yes | N/A |
 | Device Wipe | N/A | Yes | Yes | Yes | N/A |
 | Device Recovery | N/A | Yes | N/A | Yes | N/A |
 | Device Backup | N/A | N/A | Yes | N/A | Yes |
-| P2PKH Inputs | Yes | Yes | Yes | Partial | Yes |
-| P2SH-P2WPKH Inputs | Yes | Yes | Yes | Partial | Yes |
-| P2WPKH Inputs | Yes | Yes | Yes | Partial | Yes |
-| P2SH Multisig Inputs | Yes | Yes | Yes | No | N/A |
+| P2PKH Inputs | Yes | Yes | Yes | Yes | Yes |
+| P2SH-P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes |
+| P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes |
+| P2SH Multisig Inputs | Yes | Yes | Yes | Yes | N/A |
 | P2SH-P2WSH Multisig Inputs | Yes | No | Yes | No | N/A |
-| P2WSH Multisig Inputs | Yes | Yes | Yes | No | N/A |
-| Bare Multisig Inputs | Yes | N/A | Yes | No | N/A |
-| Aribtrary scriptPubKey Inputs | Yes | N/A | Yes | No | N/A |
-| Aribtrary redeemScript Inputs | Yes | N/A | Yes | No | N/A |
-| Arbitrary witnessScript Inputs | Yes | N/A | Yes | No | N/A |
+| P2WSH Multisig Inputs | Yes | No | Yes | Yes | N/A |
+| Bare Multisig Inputs | Yes | N/A | Yes | N/A | N/A |
+| Aribtrary scriptPubKey Inputs | Yes | N/A | Yes | N/A | N/A |
+| Aribtrary redeemScript Inputs | Yes | N/A | Yes | N/A | N/A |
+| Arbitrary witnessScript Inputs | Yes | N/A | Yes | N/A | N/A |
 | Non-wallet inputs | Yes | Yes | Yes | Yes | Yes |
-| Mixed Segwit and Non-Segwit Inputs | No | Yes | Yes | Partial | Yes |
-| Display on device screen | Yes | Yes | N/A | No | Yes |
+| Mixed Segwit and Non-Segwit Inputs | No | Yes | Yes | Yes | Yes |
+| Display on device screen | Yes | Yes | N/A | Yes | Yes |
 
 ## Using with Bitcoin Core
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip3 install hidapi # HID API needed in general
 pip3 install trezor[hidapi] # Trezor One
 pip3 install btchip-python # Ledger Nano S
 pip3 install ecdsa # Needed for btchip-python but is not installed by it
-pip3 install keepkey # KeepKey
+pip3 install git+git://github.com/keepkey/python-keepkey.git@43fe80ae2e54b274c7b8641ff409bce4ebe04914#egg=keepkey # KeepKey. The tags and pypi don't have the right version yet, so lock to a specific commit from their git repo
 pip3 install ckcc-protocol[cli] # Coldcard
 pip3 install pyaes # For digitalbitbox
 ```

--- a/docs/keepkey.md
+++ b/docs/keepkey.md
@@ -10,10 +10,16 @@ Current implemented commands are:
 - `wipe`
 - `restore`
 - `backup`
+- `signtx`
+- `displayaddress`
+- `signmessage`
 
-## `signtx` Notes
+## `signtx` Caveats
 
-`signtx` has an implementation but has not been tested to be working. Use at your own risk.
+Due to the limitations of the KeepKey, some transactions cannot be signed by a KeepKey.
+
+- Multisig inputs are limited to at most n-of-15 multisigs. This is a firmware limitation.
+* Transactions with arbitrary input scripts (scriptPubKey, redeemScript, or witnessScript) and arbitrary output scripts cannot be signed. This is a firmware limitation.
 
 ## Note on `backup`
 

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -9,6 +9,7 @@ from keepkeylib.tx_api import TxApi
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 from ..serializations import ser_uint256, uint256_from_str
 
+import base64
 import binascii
 import json
 import os
@@ -177,7 +178,11 @@ class KeepkeyClient(HardwareWalletClient):
     # Must return a base64 encoded string with the signed message
     # The message can be any string
     def sign_message(self, message, keypath):
-        raise NotImplementedError('The KeepKey does not currently implement signmessage')
+        keypath = keypath.replace('h', '\'')
+        keypath = keypath.replace('H', '\'')
+        expanded_path = tools.parse_path(keypath)
+        result = self.client.sign_message('Bitcoin', expanded_path, message)
+        return {'signature': base64.b64encode(result.signature).decode('utf-8')}
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -186,7 +186,16 @@ class KeepkeyClient(HardwareWalletClient):
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
-        raise NotImplementedError('The KeepKey does not currently implement displayaddress')
+        keypath = keypath.replace('h', '\'')
+        keypath = keypath.replace('H', '\'')
+        expanded_path = tools.parse_path(keypath)
+        address = self.client.get_address(
+            "Testnet" if self.is_testnet else "Bitcoin",
+            expanded_path,
+            show_display=True,
+            script_type=proto.SPENDWITNESS if bech32 else (proto.SPENDP2SHWITNESS if p2sh_p2wpkh else proto.SPENDADDRESS)
+        )
+        return {'address': address}
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -69,7 +69,7 @@ class KeepkeyClient(HardwareWalletClient):
     def get_pubkey_at_path(self, path):
         path = path.replace('h', '\'')
         path = path.replace('H', '\'')
-        expanded_path = self.client.expand_path(path)
+        expanded_path = tools.parse_path(path)
         output = self.client.get_public_node(expanded_path)
         if self.is_testnet:
             return {'xpub':xpub_main_2_test(output.xpub)}

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -4,6 +4,7 @@ from ..hwwclient import HardwareWalletClient, UnavailableActionError
 from keepkeylib.transport_hid import HidTransport
 from keepkeylib.transport_udp import UDPTransport
 from keepkeylib.client import KeepKeyClient as KeepKey
+from keepkeylib.client import KeepKeyDebugClient as KeepKeyDebug
 from keepkeylib import tools
 from keepkeylib import messages_pb2, types_pb2 as proto
 from keepkeylib.tx_api import TxApi
@@ -111,7 +112,13 @@ class KeepkeyClient(HardwareWalletClient):
         elif path.startswith('udp:'):
             path = path[4:]
             transport = UDPTransport(path)
-            self.client = KeepKey(transport)
+            # Use the debug client for the simulator
+            self.client = KeepKeyDebug(transport)
+            # Get the debug link
+            ip, port = path.split(':')
+            new_port = int(port) + 1
+            debug_transport = UDPTransport('{}:{}'.format(ip, new_port))
+            self.client.set_debuglink(debug_transport)
         else:
             raise IOError('Unknown device transport')
 

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -8,6 +8,7 @@ from keepkeylib import messages_pb2, types_pb2 as proto
 from keepkeylib.tx_api import TxApi
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 from ..serializations import ser_uint256, uint256_from_str
+from .. import bech32
 
 import base64
 import binascii
@@ -17,6 +18,8 @@ import os
 KEEPKEY_VENDOR_ID = 0x2B24
 KEEPKEY_DEVICE_ID = 0x0001
 
+py_enumerate = enumerate # Need to use the enumerate built-in but there's another function already named that
+
 class TxAPIPSBT(TxApi):
 
     def __init__(self, psbt):
@@ -24,30 +27,76 @@ class TxAPIPSBT(TxApi):
         self.psbt = psbt
 
     def get_tx(self, txhash):
-        tx = None
-        for psbt_in in self.psbt.inputs:
-            if psbt_in.non_witness_utxo and psbt_in.non_witness_utxo.sha256 == uint256_from_str(binascii.unhexlify(txhash)[::-1]):
-                tx = psbt_in.non_witness_utxo
-        if not tx:
-            raise ValueError("TX {} not found in PSBT".format(txhash))
+        # Find index of the input
+        for i, input in py_enumerate(self.psbt.tx.vin):
+            if input.prevout.hash == uint256_from_str(binascii.unhexlify(txhash)[::-1]):
+                break
 
+        psbt_in = self.psbt.inputs[i]
         t = proto.TransactionType()
-        t.version = tx.nVersion
-        t.lock_time = tx.nLockTime
+        if psbt_in.non_witness_utxo:
+            assert(psbt_in.non_witness_utxo.sha256 == uint256_from_str(binascii.unhexlify(txhash)[::-1]))
+            tx = psbt_in.non_witness_utxo
 
-        for vin in tx.vin:
-            i = t.inputs.add()
-            i.prev_hash = ser_uint256(vin.prevout.hash)[::-1]
-            i.prev_index = vin.prevout.n
-            i.script_sig = vin.scriptSig
-            i.sequence = vin.nSequence
+            t.version = tx.nVersion
+            t.lock_time = tx.nLockTime
 
-        for vout in tx.vout:
+            for vin in tx.vin:
+                i = t.inputs.add()
+                i.prev_hash = ser_uint256(vin.prevout.hash)[::-1]
+                i.prev_index = vin.prevout.n
+                i.script_sig = vin.scriptSig
+                i.sequence = vin.nSequence
+
+            for vout in tx.vout:
+                o = t.bin_outputs.add()
+                o.amount = vout.nValue
+                o.script_pubkey = vout.scriptPubKey
+        elif psbt_in.witness_utxo:
+            # HACK: the library looks up this info for all inputs. we just need to appease it for segwit stuff
+            t.version = 1
+            t.lock_time = 0
             o = t.bin_outputs.add()
-            o.amount = vout.nValue
-            o.script_pubkey = vout.scriptPubKey
+            o.amount = psbt_in.witness_utxo.nValue
+            o.script_pubkey = psbt_in.witness_utxo.scriptPubKey
+        else:
+            raise ValueError('{} is not an input in this transaction'.format(txhash))
 
         return t
+
+# Only handles up to 15 of 15
+def parse_multisig(script):
+    # Get m
+    m = script[0] - 80
+    if m < 1 or m > 15:
+        return (False, None)
+
+    # Get pubkeys and build HDNodePathType
+    pubkeys = []
+    offset = 1
+    while True:
+        pubkey_len = script[offset]
+        if pubkey_len != 33:
+            break
+        offset += 1
+        key = script[offset:offset + 33]
+        offset += 33
+
+        hd_node = proto.HDNodeType(depth=0, fingerprint=0, child_num=0, chain_code=b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', public_key=key)
+        pubkeys.append(proto.HDNodePathType(node=hd_node, address_n=[]))
+
+    # Check things at the end
+    n = script[offset] - 80
+    if n != len(pubkeys):
+        return (False, None)
+    offset += 1
+    op_cms = script[offset]
+    if op_cms != 174:
+        return (False, None)
+
+    # Build MultisigRedeemScriptType and return it
+    multisig = proto.MultisigRedeemScriptType(m=m, signatures=[b''] * n, pubkeys=pubkeys)
+    return (True, multisig)
 
 # This class extends the HardwareWalletClient for Digital Bitbox specific things
 class KeepkeyClient(HardwareWalletClient):
@@ -85,93 +134,146 @@ class KeepkeyClient(HardwareWalletClient):
         master_key = self.client.get_public_node([0])
         master_fp = get_xpub_fingerprint(master_key.xpub)
 
-        # Prepare inputs
-        inputs = []
-        for psbt_in, txin in zip(tx.inputs, tx.tx.vin):
-            txinputtype = proto.TxInputType()
+        # Do multiple passes for multisig
+        passes = 1
+        p = 0
 
-            # Set the input stuff
-            txinputtype.prev_hash = ser_uint256(txin.prevout.hash)[::-1]
-            txinputtype.prev_index = txin.prevout.n
-            txinputtype.sequence = txin.nSequence
+        while p < passes:
+            # Prepare inputs
+            inputs = []
+            to_ignore = []
+            for input_num, (psbt_in, txin) in py_enumerate(list(zip(tx.inputs, tx.tx.vin))):
+                txinputtype = proto.TxInputType()
 
-            # Detrermine spend type
-            if psbt_in.non_witness_utxo:
-                txinputtype.script_type = 0
-            elif psbt_in.witness_utxo:
-                # Check if the output is p2sh
-                if psbt_in.witness_utxo.is_p2sh():
-                    txinputtype.script_type = 3
+                # Set the input stuff
+                txinputtype.prev_hash = ser_uint256(txin.prevout.hash)[::-1]
+                txinputtype.prev_index = txin.prevout.n
+                txinputtype.sequence = txin.nSequence
+
+                # Detrermine spend type
+                scriptcode = b''
+                if psbt_in.non_witness_utxo:
+                    utxo = psbt_in.non_witness_utxo.vout[txin.prevout.n]
+                    txinputtype.script_type = proto.SPENDADDRESS
+                    scriptcode = utxo.scriptPubKey
+                    txinputtype.amount = psbt_in.non_witness_utxo.vout[txin.prevout.n].nValue
+                elif psbt_in.witness_utxo:
+                    utxo = psbt_in.witness_utxo
+                    # Check if the output is p2sh
+                    if psbt_in.witness_utxo.is_p2sh():
+                        txinputtype.script_type = proto.SPENDP2SHWITNESS
+                    else:
+                        txinputtype.script_type = proto.SPENDWITNESS
+                    scriptcode = psbt_in.witness_utxo.scriptPubKey
+                    txinputtype.amount = psbt_in.witness_utxo.nValue
+
+                # Set the script
+                if psbt_in.witness_script:
+                    scriptcode = psbt_in.witness_script
+                elif psbt_in.redeem_script:
+                    scriptcode = psbt_in.redeem_script
+
+                def ignore_input():
+                    txinputtype.address_n.extend([0x80000000])
+                    txinputtype.ClearField('multisig')
+                    txinputtype.script_type = proto.SPENDWITNESS
+                    inputs.append(txinputtype)
+                    to_ignore.append(input_num)
+
+                # Check for multisig
+                is_ms, multisig = parse_multisig(scriptcode)
+                if is_ms:
+                    # Add to txinputtype
+                    txinputtype.multisig.CopyFrom(multisig)
+                    if psbt_in.non_witness_utxo:
+                        if utxo.is_p2sh:
+                            txinputtype.script_type = proto.SPENDMULTISIG
+                        else:
+                            # Cannot sign bare multisig, ignore it
+                            ignore_input()
+                            continue
+                elif not is_ms and psbt_in.non_witness_utxo and not utxo.is_p2pkh:
+                    # Cannot sign unknown spk, ignore it
+                    ignore_input()
+                    continue
+                elif not is_ms and psbt_in.witness_utxo and psbt_in.witness_script:
+                    # Cannot sign unknown witness script, ignore it
+                    ignore_input()
+                    continue
+
+                # Find key to sign with
+                found = False
+                our_keys = 0
+                for key in psbt_in.hd_keypaths.keys():
+                    keypath = psbt_in.hd_keypaths[key]
+                    if keypath[0] == master_fp and key not in psbt_in.partial_sigs:
+                        if not found:
+                            txinputtype.address_n.extend(keypath[1:])
+                            found = True
+                        our_keys += 1
+
+                # Determine if we need to do more passes to sign everything
+                if our_keys > passes:
+                    passes = our_keys
+
+                if not found:
+                    # This input is not one of ours
+                    ignore_input()
+                    continue
+
+                # append to inputs
+                inputs.append(txinputtype)
+
+            # address version byte
+            if self.is_testnet:
+                p2pkh_version = b'\x6f'
+                p2sh_version = b'\xc4'
+                bech32_hrp = 'tb'
+            else:
+                p2pkh_version = b'\x00'
+                p2sh_version = b'\x05'
+                bech32_hrp = 'bc'
+
+            # prepare outputs
+            outputs = []
+            for out in tx.tx.vout:
+                txoutput = proto.TxOutputType()
+                txoutput.amount = out.nValue
+                txoutput.script_type = proto.PAYTOADDRESS
+                if out.is_p2pkh():
+                    txoutput.address = to_address(out.scriptPubKey[3:23], p2pkh_version)
+                    txoutput.script_type = 0
+                elif out.is_p2sh():
+                    txoutput.address = to_address(out.scriptPubKey[2:22], p2sh_version)
+                    txoutput.script_type = 1
                 else:
-                    txinputtype.script_type = 4
+                    wit, ver, prog = out.is_witness()
+                    if wit:
+                        txoutput.address = bech32.encode(bech32_hrp, ver, prog)
+                    else:
+                        raise TypeError("Output is not an address")
 
-            # Check for 1 key
-            if len(psbt_in.hd_keypaths) == 1:
-                # Is this key ours
-                pubkey = list(psbt_in.hd_keypaths.keys())[0]
-                fp = psbt_in.hd_keypaths[pubkey][0]
-                keypath = psbt_in.hd_keypaths[pubkey][1:]
-                if fp == master_fp:
-                    # Set the keypath
-                    txinputtype.address_n.extend(keypath)
+                # append to outputs
+                outputs.append(txoutput)
 
-            # Check for multisig (more than 1 key)
-            elif len(psbt_in.hd_keypaths) > 1:
-                raise TypeError("Cannot sign multisig yet")
+            # Sign the transaction
+            self.client.set_tx_api(TxAPIPSBT(tx))
+            if self.is_testnet:
+                signed_tx = self.client.sign_tx("Testnet", inputs, outputs, tx.tx.nVersion, tx.tx.nLockTime)
             else:
-                raise TypeError("All inputs must have a key for this device")
+                signed_tx = self.client.sign_tx("Bitcoin", inputs, outputs, tx.tx.nVersion, tx.tx.nLockTime)
 
-            # Set the amount
-            if psbt_in.non_witness_utxo:
-                txinputtype.amount = psbt_in.non_witness_utxo.vout[txin.prevout.n].nValue
-            elif psbt_in.witness_utxo:
-                txinputtype.amount = psbt_in.witness_utxo.nValue
+            # Each input has one signature
+            for input_num, (psbt_in, sig) in py_enumerate(list(zip(tx.inputs, signed_tx[0]))):
+                if input_num in to_ignore:
+                    continue
+                for pubkey in psbt_in.hd_keypaths.keys():
+                    fp = psbt_in.hd_keypaths[pubkey][0]
+                    if fp == master_fp and pubkey not in psbt_in.partial_sigs:
+                        psbt_in.partial_sigs[pubkey] = sig + b'\x01'
+                        break
 
-            # append to inputs
-            inputs.append(txinputtype)
-
-        # address version byte
-        if self.is_testnet:
-            p2pkh_version = b'\x6f'
-            p2sh_version = b'\xc4'
-        else:
-            p2pkh_version = b'\x00'
-            p2sh_version = b'\x05'
-
-        # prepare outputs
-        outputs = []
-        for out in tx.tx.vout:
-            txoutput = proto.TxOutputType()
-            txoutput.amount = out.nValue
-            if out.is_p2pkh():
-                txoutput.address = to_address(out.scriptPubKey[3:23], p2pkh_version)
-                txoutput.script_type = 0
-            elif out.is_p2sh():
-                txoutput.address = to_address(out.scriptPubKey[2:22], p2sh_version)
-                txoutput.script_type = 1
-            else:
-                # TODO: Figure out what to do here. for now, just break
-                break
-
-            # append to outputs
-            outputs.append(txoutput)
-            logging.debug(txoutput)
-
-        # Sign the transaction
-        self.client.set_tx_api(TxAPIPSBT(tx))
-        if self.is_testnet:
-            signed_tx = self.client.sign_tx("Testnet", inputs, outputs, tx.tx.nVersion, tx.tx.nLockTime)
-        else:
-            signed_tx = self.client.sign_tx("Bitcoin", inputs, outputs, tx.tx.nVersion, tx.tx.nLockTime)
-
-        signatures = signed_tx[0]
-        logging.debug(binascii.hexlify(signed_tx[1]))
-        for psbt_in in tx.inputs:
-            for pubkey, sig in zip(psbt_in.hd_keypaths.keys(), signatures):
-                fp = psbt_in.hd_keypaths[pubkey][0]
-                keypath = psbt_in.hd_keypaths[pubkey][1:]
-                if fp == master_fp:
-                    psbt_in.partial_sigs[pubkey] = sig + b'\x01'
+            p += 1
 
         return {'psbt':tx.serialize()}
 

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -2,6 +2,7 @@
 
 from ..hwwclient import HardwareWalletClient, UnavailableActionError
 from keepkeylib.transport_hid import HidTransport
+from keepkeylib.transport_udp import UDPTransport
 from keepkeylib.client import KeepKeyClient as KeepKey
 from keepkeylib import tools
 from keepkeylib import messages_pb2, types_pb2 as proto
@@ -103,9 +104,16 @@ class KeepkeyClient(HardwareWalletClient):
 
     def __init__(self, path, password=''):
         super(KeepkeyClient, self).__init__(path, password)
-        devices = HidTransport.enumerate()
-        transport = HidTransport((path.encode(), None))
-        self.client = KeepKey(transport)
+        if path.startswith('hid:'):
+            path = path[4:]
+            transport = HidTransport((path.encode(), None))
+            self.client = KeepKey(transport)
+        elif path.startswith('udp:'):
+            path = path[4:]
+            transport = UDPTransport(path)
+            self.client = KeepKey(transport)
+        else:
+            raise IOError('Unknown device transport')
 
         # if it wasn't able to find a client, throw an error
         if not self.client:
@@ -326,10 +334,24 @@ class KeepkeyClient(HardwareWalletClient):
 
 def enumerate(password=''):
     results = []
+    paths = []
     for d in HidTransport.enumerate():
+        paths.append('hid:{}'.format(d[0].decode()))
+
+    # Try to open the simulator device and conenct to it
+    try:
+        sim_dev = UDPTransport('127.0.0.1:21324')
+        sim_dev.socket.sendall(b"PINGPING")
+        resp = sim_dev.socket.recv(8)
+        if resp != b'PONGPONG':
+            pass
+        paths.append('udp:127.0.0.1:21324')
+    except:
+        pass
+
+    for path in paths:
         d_data = {}
 
-        path = d[0].decode()
         d_data['type'] = 'keepkey'
         d_data['path'] = path
 
@@ -342,6 +364,8 @@ def enumerate(password=''):
                 d_data['error'] = 'Not initialized'
             client.close()
         except Exception as e:
+            if str(e) == 'Unsupported device':
+                continue
             d_data['error'] = "Could not open client or get fingerprint information: " + str(e)
 
         results.append(d_data)

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -323,6 +323,9 @@ def enumerate(password=''):
             else:
                 d_data['error'] = 'Not initialized'
             client.close()
+        except TypeError as e:
+            if dev.get_path().startswith('udp:'):
+                continue
         except Exception as e:
             d_data['error'] = "Could not open client or get fingerprint information: " + str(e)
 

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,13 @@ setuptools.setup(
         'hidapi', # HID API needed in general
         'trezor>=0.11.0', # Trezor One
         'btchip-python', # Ledger Nano S
-        'keepkey', # KeepKey
+        'keepkey==6.0.1', # KeepKey
         'ckcc-protocol[cli]', # Coldcard
         'pyaes',
         'ecdsa', # Needed for Ledger but their library does not install it
+    ],
+    dependency_links=[
+        'https://github.com/keepkey/python-keepkey/tarball/43fe80ae2e54b274c7b8641ff409bce4ebe04914#egg=keepkey-6.0.1' # The tags don't have the right version yet, so lock to a specific commit
     ],
     python_requires='>=3',
     classifiers=[

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -12,6 +12,7 @@ from test_psbt import TestPSBT
 from test_trezor import trezor_test_suite
 from test_ledger import ledger_test_suite
 from test_digitalbitbox import digitalbitbox_test_suite
+from test_keepkey import keepkey_test_suite
 
 parser = argparse.ArgumentParser(description='Setup the testing environment and run automated tests')
 trezor_group = parser.add_mutually_exclusive_group()
@@ -22,6 +23,9 @@ coldcard_group.add_argument('--no_coldcard', help='Do not run Coldcard test with
 coldcard_group.add_argument('--coldcard', help='Path to Coldcard simulator.', default='work/firmware/unix/headless.py')
 ledger_group = parser.add_mutually_exclusive_group()
 ledger_group.add_argument('--ledger', help='Run physical Ledger Nano S/X tests.', action='store_true')
+keepkey_group = parser.add_mutually_exclusive_group()
+keepkey_group.add_argument('--no_keepkey', help='Do not run Keepkey test with emulator', action='store_true')
+keepkey_group.add_argument('--keepkey', help='Path to Keepkey emulator.', default='work/keepkey-firmware/bin/kkemu')
 
 parser.add_argument('--digitalbitbox', help='Run physical Digital Bitbox tests.', action='store_true')
 parser.add_argument('--bitcoind', help='Path to bitcoind.', default='work/bitcoin/src/bitcoind')
@@ -48,5 +52,7 @@ if args.digitalbitbox:
         suite.addTest(digitalbitbox_test_suite(rpc, userpass, args.password))
     else:
         print('Cannot run Digital Bitbox test without --password set')
-result = unittest.TextTestRunner().run(suite)
+if not args.no_keepkey:
+    suite.addTest(keepkey_test_suite(args.keepkey, rpc, userpass))
+result = unittest.TextTestRunner(stream=sys.stdout).run(suite)
 sys.exit(not result.wasSuccessful())

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -333,8 +333,8 @@ class TestSignTx(DeviceTestCase):
 
     # Test wrapper to avoid mixed-inputs signing for Ledger
     def test_signtx(self):
-        supports_mixed = {'coldcard', 'trezor', 'digitalbitbox'}
-        supports_multisig = {'ledger', 'trezor', 'digitalbitbox'}
+        supports_mixed = {'coldcard', 'trezor', 'digitalbitbox', 'keepkey'}
+        supports_multisig = {'ledger', 'trezor', 'digitalbitbox', 'keepkey'}
         if self.type not in supports_mixed:
             self._test_signtx("legacy", self.type in supports_multisig)
             self._test_signtx("segwit", self.type in supports_multisig)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -12,6 +12,13 @@ from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
 from hwilib.commands import process_commands
 from hwilib.serializations import PSBT
 
+# Class for emulator control
+class DeviceEmulator():
+    def start(self):
+        pass
+    def stop(self):
+        pass
+
 def start_bitcoind(bitcoind_path):
     datadir = tempfile.mkdtemp()
     bitcoind_proc = subprocess.Popen([bitcoind_path, '-regtest', '-datadir=' + datadir, '-noprinttoconsole'])
@@ -42,7 +49,7 @@ def start_bitcoind(bitcoind_path):
     return (rpc, userpass)
 
 class DeviceTestCase(unittest.TestCase):
-    def __init__(self, rpc, rpc_userpass, type, path, fingerprint, master_xpub, password = '', methodName='runTest'):
+    def __init__(self, rpc, rpc_userpass, type, path, fingerprint, master_xpub, password = '', emulator=None, methodName='runTest'):
         super(DeviceTestCase, self).__init__(methodName)
         self.rpc = rpc
         self.rpc_userpass = rpc_userpass
@@ -52,19 +59,29 @@ class DeviceTestCase(unittest.TestCase):
         self.master_xpub = master_xpub
         self.password = password
         self.dev_args = ['-t', self.type, '-d', self.path]
+        if emulator:
+            self.emulator = emulator
+        else:
+            self.emulator = DeviceEmulator()
         if password:
             self.dev_args.extend(['-p', password])
 
     @staticmethod
-    def parameterize(testclass, rpc, rpc_userpass, type, path, fingerprint, master_xpub, password = ''):
+    def parameterize(testclass, rpc, rpc_userpass, type, path, fingerprint, master_xpub, password = '', emulator=None):
         testloader = unittest.TestLoader()
         testnames = testloader.getTestCaseNames(testclass)
         suite = unittest.TestSuite()
         for name in testnames:
-            suite.addTest(testclass(rpc, rpc_userpass, type, path, fingerprint, master_xpub, password, name))
+            suite.addTest(testclass(rpc, rpc_userpass, type, path, fingerprint, master_xpub, password, emulator, name))
         return suite
 
 class TestDeviceConnect(DeviceTestCase):
+    def setUp(self):
+        self.emulator.start()
+
+    def tearDown(self):
+        self.emulator.stop()
+
     def test_enumerate(self):
         enum_res = process_commands(['-p', self.password, 'enumerate'])
         found = False
@@ -102,6 +119,10 @@ class TestGetKeypool(DeviceTestCase):
         self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
         if '--testnet' not in self.dev_args:
             self.dev_args.append('--testnet')
+        self.emulator.start()
+
+    def tearDown(self):
+        self.emulator.stop()
 
     def test_getkeypool_bad_args(self):
         result = process_commands(self.dev_args + ['getkeypool', '--sh_wpkh', '--wpkh', '0', '20'])
@@ -205,6 +226,10 @@ class TestSignTx(DeviceTestCase):
         self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
         if '--testnet' not in self.dev_args:
             self.dev_args.append('--testnet')
+        self.emulator.start()
+
+    def tearDown(self):
+        self.emulator.stop()
 
     def _generate_and_finalize(self, unknown_inputs, psbt):
         if not unknown_inputs:
@@ -342,6 +367,11 @@ class TestSignTx(DeviceTestCase):
             self._test_signtx("all", self.type in supports_multisig)
 
 class TestDisplayAddress(DeviceTestCase):
+    def setUp(self):
+        self.emulator.start()
+
+    def tearDown(self):
+        self.emulator.stop()
 
     def test_display_address_bad_args(self):
         result = process_commands(self.dev_args + ['displayaddress', '--sh_wpkh', '--wpkh', 'm/49h/1h/0h/0/0'])
@@ -355,6 +385,11 @@ class TestDisplayAddress(DeviceTestCase):
         process_commands(self.dev_args + ['displayaddress', '--wpkh', 'm/84h/1h/0h/0/0'])
 
 class TestSignMessage(DeviceTestCase):
+    def setUp(self):
+        self.emulator.start()
+
+    def tearDown(self):
+        self.emulator.stop()
 
     def test_sign_msg(self):
         process_commands(self.dev_args + ['signmessage', 'Message signing test', 'm/44h/1h/0h/0/0'])

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -1,0 +1,106 @@
+#! /usr/bin/env python3
+
+import argparse
+import atexit
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+import time
+import unittest
+
+from keepkeylib.transport_udp import UDPTransport
+from keepkeylib.client import KeepKeyDebugClient
+from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignTx
+
+from hwilib.commands import process_commands
+
+emulator_proc = None
+
+def start_emulator():
+    # Start the Keepkey emulator
+    emulator_proc = subprocess.Popen([emulator])
+    # Wait for emulator to be up
+    # From https://github.com/trezor/trezor-mcu/blob/master/script/wait_for_emulator.py
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.connect(('127.0.0.1', 21324))
+    sock.settimeout(0)
+    while True:
+        try:
+            sock.sendall(b"PINGPING")
+            r = sock.recv(8)
+            if r == b"PONGPONG":
+                break
+        except Exception:
+            time.sleep(0.05)
+
+    # Setup the emulator
+    sim_dev = UDPTransport('127.0.0.1:21324')
+    sim_dev.buffer = b'' # HACK to work around a bug in the keepkey library
+    sim_dev_debug = UDPTransport('127.0.0.1:21325')
+    sim_dev_debug.buffer = b'' # HACK to work around a bug in the keepkey library
+    client = KeepKeyDebugClient(sim_dev)
+    client.set_debuglink(sim_dev_debug)
+    client.wipe_device()
+    client.load_device_by_mnemonic(mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=False, label='test', language='english') # From Trezor device tests
+    return client
+
+def stop_emulator():
+    if emulator_proc:
+        emulator_proc.kill()
+
+# Keepkey specific getxpub test because this requires device specific thing to set xprvs
+class TestKeepkeyGetxpub(unittest.TestCase):
+    def setUp(self):
+        self.client = start_emulator()
+    
+    def test_getxpub(self):
+        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/bip32_vectors.json'), encoding='utf-8') as f:
+            vectors = json.load(f)
+        for vec in vectors:
+            with self.subTest(vector=vec):
+                # Setup with xprv
+                self.client.wipe_device()
+                self.client.load_device_by_xprv(xprv=vec['xprv'], pin='', passphrase_protection=False, label='test', language='english')
+
+                # Test getmasterxpub
+                gmxp_res = process_commands(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub'])
+                self.assertEqual(gmxp_res['xpub'], vec['master_xpub'])
+
+                # Test the path derivs
+                for path_vec in vec['vectors']:
+                    gxp_res = process_commands(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', 'getxpub', path_vec['path']])
+                    self.assertEqual(gxp_res['xpub'], path_vec['xpub'])
+
+def keepkey_test_suite(emulator, rpc, userpass):
+    # Redirect stderr to /dev/null as it's super spammy
+    sys.stderr = open(os.devnull, 'w')
+
+    # Device info for tests
+    type = 'keepkey'
+    path = 'udp:127.0.0.1:21324'
+    fingerprint = '95d8f670'
+    master_xpub = 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'
+
+    # Generic Device tests
+    suite = unittest.TestSuite()
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, type, path, fingerprint, master_xpub))
+    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, type, path, fingerprint, master_xpub))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, path, fingerprint, master_xpub))
+    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, type, path, fingerprint, master_xpub))
+    suite.addTest(TestKeepkeyGetxpub())
+    return suite
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test Keepkey implementation')
+    parser.add_argument('emulator', help='Path to the Keepkey emulator')
+    parser.add_argument('bitcoind', help='Path to bitcoind binary')
+    args = parser.parse_args()
+
+    # Start bitcoind
+    rpc, userpass = start_bitcoind(args.bitcoind)
+
+    suite = keepkey_test_suite(args.emulator, rpc, userpass)
+    unittest.TextTestRunner(stream=sys.stdout).run(suite)

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -13,48 +13,73 @@ import unittest
 
 from keepkeylib.transport_udp import UDPTransport
 from keepkeylib.client import KeepKeyDebugClient
-from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignTx
+from test_device import DeviceEmulator, DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignTx
 
 from hwilib.commands import process_commands
 
-emulator_proc = None
+class KeepkeyEmulator(DeviceEmulator):
+    def __init__(self, emulator_path):
+        self.emulator_proc = None
+        self.emulator_path = emulator_path
 
-def start_emulator():
-    # Start the Keepkey emulator
-    emulator_proc = subprocess.Popen([emulator])
-    # Wait for emulator to be up
-    # From https://github.com/trezor/trezor-mcu/blob/master/script/wait_for_emulator.py
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.connect(('127.0.0.1', 21324))
-    sock.settimeout(0)
-    while True:
-        try:
-            sock.sendall(b"PINGPING")
-            r = sock.recv(8)
-            if r == b"PONGPONG":
-                break
-        except Exception:
-            time.sleep(0.05)
+    def start(self):
+        # Start the Keepkey emulator
+        self.emulator_proc = subprocess.Popen(['./' + os.path.basename(self.emulator_path)], cwd=os.path.dirname(self.emulator_path), stdout=subprocess.DEVNULL)
+        # Wait for emulator to be up
+        # From https://github.com/trezor/trezor-mcu/blob/master/script/wait_for_emulator.py
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect(('127.0.0.1', 21324))
+        sock.settimeout(0)
+        while True:
+            try:
+                sock.sendall(b"PINGPING")
+                r = sock.recv(8)
+                if r == b"PONGPONG":
+                    break
+            except Exception:
+                time.sleep(0.05)
 
-    # Setup the emulator
-    sim_dev = UDPTransport('127.0.0.1:21324')
-    sim_dev.buffer = b'' # HACK to work around a bug in the keepkey library
-    sim_dev_debug = UDPTransport('127.0.0.1:21325')
-    sim_dev_debug.buffer = b'' # HACK to work around a bug in the keepkey library
-    client = KeepKeyDebugClient(sim_dev)
-    client.set_debuglink(sim_dev_debug)
-    client.wipe_device()
-    client.load_device_by_mnemonic(mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=False, label='test', language='english') # From Trezor device tests
-    return client
+        # Redirect stdout to /dev/null as the keepkey lib kind of spammy
+        sys.stdout = open(os.devnull, 'w')
 
-def stop_emulator():
-    if emulator_proc:
-        emulator_proc.kill()
+        # Setup the emulator
+        sim_dev = UDPTransport('127.0.0.1:21324')
+        sim_dev.buffer = b'' # HACK to work around a bug in the keepkey library
+        sim_dev_debug = UDPTransport('127.0.0.1:21325')
+        sim_dev_debug.buffer = b'' # HACK to work around a bug in the keepkey library
+        client = KeepKeyDebugClient(sim_dev)
+        client.set_debuglink(sim_dev_debug)
+        client.wipe_device()
+        client.load_device_by_mnemonic(mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=False, label='test', language='english') # From Trezor device tests
+        return client
+
+    def stop(self):
+        self.emulator_proc.kill()
+        self.emulator_proc.wait()
+        # Redirect stdout back to stdout
+        sys.stdout = sys.__stdout__
+
+class KeepkeyTestCase(unittest.TestCase):
+    def __init__(self, emulator, methodName='runTest'):
+        super(KeepkeyTestCase, self).__init__(methodName)
+        self.emulator = emulator
+
+    @staticmethod
+    def parameterize(testclass, emulator):
+        testloader = unittest.TestLoader()
+        testnames = testloader.getTestCaseNames(testclass)
+        suite = unittest.TestSuite()
+        for name in testnames:
+            suite.addTest(testclass(emulator, name))
+        return suite
 
 # Keepkey specific getxpub test because this requires device specific thing to set xprvs
-class TestKeepkeyGetxpub(unittest.TestCase):
+class TestKeepkeyGetxpub(KeepkeyTestCase):
     def setUp(self):
-        self.client = start_emulator()
+        self.client = self.emulator.start()
+
+    def tearDown(self):
+        self.emulator.stop()
     
     def test_getxpub(self):
         with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/bip32_vectors.json'), encoding='utf-8') as f:
@@ -83,14 +108,15 @@ def keepkey_test_suite(emulator, rpc, userpass):
     path = 'udp:127.0.0.1:21324'
     fingerprint = '95d8f670'
     master_xpub = 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'
+    dev_emulator = KeepkeyEmulator(emulator)
 
     # Generic Device tests
     suite = unittest.TestSuite()
-    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, type, path, fingerprint, master_xpub))
-    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, type, path, fingerprint, master_xpub))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, path, fingerprint, master_xpub))
-    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, type, path, fingerprint, master_xpub))
-    suite.addTest(TestKeepkeyGetxpub())
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, type, path, fingerprint, master_xpub, emulator=dev_emulator))
+    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, type, path, fingerprint, master_xpub, emulator=dev_emulator))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, path, fingerprint, master_xpub, emulator=dev_emulator))
+    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, type, path, fingerprint, master_xpub, emulator=dev_emulator))
+    suite.addTest(KeepkeyTestCase.parameterize(TestKeepkeyGetxpub, emulator=dev_emulator))
     return suite
 
 if __name__ == '__main__':

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -6,6 +6,7 @@ import json
 import os
 import socket
 import subprocess
+import sys
 import time
 import unittest
 
@@ -14,82 +15,105 @@ from trezorlib.transport import enumerate_devices
 from trezorlib.transport.udp import UdpTransport
 from trezorlib.debuglink import TrezorClientDebugLink, load_device_by_mnemonic, load_device_by_xprv
 from trezorlib import device
-from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignTx
+from test_device import DeviceEmulator, DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignTx
 
 from hwilib.commands import process_commands
 
-def trezor_test_suite(emulator, rpc, userpass):
-    # Start the Trezor emulator
-    emulator_proc = subprocess.Popen([emulator])
-    # Wait for emulator to be up
-    # From https://github.com/trezor/trezor-mcu/blob/master/script/wait_for_emulator.py
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.connect(('127.0.0.1', 21324))
-    sock.settimeout(0)
-    while True:
-        try:
-            sock.sendall(b"PINGPING")
-            r = sock.recv(8)
-            if r == b"PONGPONG":
+class TrezorEmulator(DeviceEmulator):
+    def __init__(self, path):
+        self.emulator_path = path
+        self.emulator_proc = None
+
+    def start(self):
+        # Start the Trezor emulator
+        self.emulator_proc = subprocess.Popen(['./' + os.path.basename(self.emulator_path)], cwd=os.path.dirname(self.emulator_path))
+        # Wait for emulator to be up
+        # From https://github.com/trezor/trezor-mcu/blob/master/script/wait_for_emulator.py
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect(('127.0.0.1', 21324))
+        sock.settimeout(0)
+        while True:
+            try:
+                sock.sendall(b"PINGPING")
+                r = sock.recv(8)
+                if r == b"PONGPONG":
+                    break
+            except Exception:
+                time.sleep(0.05)
+
+        # Setup the emulator
+        for dev in enumerate_devices():
+            # Find the udp transport, that's the emulator
+            if isinstance(dev, UdpTransport):
+                wirelink = dev
                 break
-        except Exception:
-            time.sleep(0.05)
-    # Cleanup
-    def cleanup_emulator():
-        emulator_proc.kill()
-    atexit.register(cleanup_emulator)
+        client = TrezorClientDebugLink(wirelink)
+        device.wipe(client)
+        load_device_by_mnemonic(client=client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=False, label='test') # From Trezor device tests
+        return client
 
-    # Setup the emulator
-    for dev in enumerate_devices():
-        # Find the udp transport, that's the emulator
-        if isinstance(dev, UdpTransport):
-            wirelink = dev
-            break
-    client = TrezorClientDebugLink(wirelink)
-    device.wipe(client)
-    load_device_by_mnemonic(client=client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=False, label='test') # From Trezor device tests
+    def stop(self):
+        self.emulator_proc.kill()
+        self.emulator_proc.wait()
 
-    class TrezorTestCase(unittest.TestCase):
-        def __init__(self, client, methodName='runTest'):
-            super(TrezorTestCase, self).__init__(methodName)
-            self.client = client
+class TrezorTestCase(unittest.TestCase):
+    def __init__(self, emulator, methodName='runTest'):
+        super(TrezorTestCase, self).__init__(methodName)
+        self.emulator = emulator
 
-        @staticmethod
-        def parameterize(testclass, client):
-            testloader = unittest.TestLoader()
-            testnames = testloader.getTestCaseNames(testclass)
-            suite = unittest.TestSuite()
-            for name in testnames:
-                suite.addTest(testclass(client, name))
-            return suite
+    @staticmethod
+    def parameterize(testclass, emulator):
+        testloader = unittest.TestLoader()
+        testnames = testloader.getTestCaseNames(testclass)
+        suite = unittest.TestSuite()
+        for name in testnames:
+            suite.addTest(testclass(emulator, name))
+        return suite
 
-    # Trezor specific getxpub test because this requires device specific thing to set xprvs
-    class TestTrezorGetxpub(TrezorTestCase):
-        def test_getxpub(self):
-            with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/bip32_vectors.json'), encoding='utf-8') as f:
-                vectors = json.load(f)
-            for vec in vectors:
-                with self.subTest(vector=vec):
-                    # Setup with xprv
-                    device.wipe(self.client)
-                    load_device_by_xprv(client=self.client, xprv=vec['xprv'], pin='', passphrase_protection=False, label='test', language='english')
+# Trezor specific getxpub test because this requires device specific thing to set xprvs
+class TestTrezorGetxpub(TrezorTestCase):
+    def setUp(self):
+        self.client = self.emulator.start()
 
-                    # Test getmasterxpub
-                    gmxp_res = process_commands(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub'])
-                    self.assertEqual(gmxp_res['xpub'], vec['master_xpub'])
+    def tearDown(self):
+        self.emulator.stop()
 
-                    # Test the path derivs
-                    for path_vec in vec['vectors']:
-                        gxp_res = process_commands(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getxpub', path_vec['path']])
-                        self.assertEqual(gxp_res['xpub'], path_vec['xpub'])
+    def test_getxpub(self):
+        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/bip32_vectors.json'), encoding='utf-8') as f:
+            vectors = json.load(f)
+        for vec in vectors:
+            with self.subTest(vector=vec):
+                # Setup with xprv
+                device.wipe(self.client)
+                load_device_by_xprv(client=self.client, xprv=vec['xprv'], pin='', passphrase_protection=False, label='test', language='english')
+
+                # Test getmasterxpub
+                gmxp_res = process_commands(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub'])
+                self.assertEqual(gmxp_res['xpub'], vec['master_xpub'])
+
+                # Test the path derivs
+                for path_vec in vec['vectors']:
+                    gxp_res = process_commands(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getxpub', path_vec['path']])
+                    self.assertEqual(gxp_res['xpub'], path_vec['xpub'])
+
+def trezor_test_suite(emulator, rpc, userpass):
+    # Redirect stderr to /dev/null as it's super spammy
+    sys.stderr = open(os.devnull, 'w')
+
+    # Device info for tests
+    type = 'trezor'
+    path = 'udp:127.0.0.1:21324'
+    fingerprint = '95d8f670'
+    master_xpub = 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'
+    dev_emulator = TrezorEmulator(emulator)
 
     # Generic Device tests
     suite = unittest.TestSuite()
-    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'trezor', 'udp:127.0.0.1:21324', '95d8f670', 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'))
-    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, 'trezor', 'udp:127.0.0.1:21324', '95d8f670', 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, 'trezor', 'udp:127.0.0.1:21324', '95d8f670', 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'))
-    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, 'trezor', 'udp:127.0.0.1:21324', '95d8f670', 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'))
-    suite.addTest(TrezorTestCase.parameterize(TestTrezorGetxpub, client))
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, type, path, fingerprint, master_xpub, emulator=dev_emulator))
+    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, type, path, fingerprint, master_xpub, emulator=dev_emulator))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, path, fingerprint, master_xpub, emulator=dev_emulator))
+    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, type, path, fingerprint, master_xpub, emulator=dev_emulator))
+    suite.addTest(TrezorTestCase.parameterize(TestTrezorGetxpub, emulator=dev_emulator))
     return suite
 
 if __name__ == '__main__':
@@ -102,4 +126,4 @@ if __name__ == '__main__':
     rpc, userpass = start_bitcoind(args.bitcoind)
 
     suite = trezor_test_suite(args.emulator, rpc, userpass)
-    unittest.TextTestRunner().run(suite)
+    unittest.TextTestRunner(stream=sys.stdout).run(suite)


### PR DESCRIPTION
Implements the signmessage, displayaddress, and signtx commands for the keepkey. This also completes its implementation and the documentation is updated as such.

Note that because the Keepkey is a clone of the Trezor, these implementations are copies of the Trezor ones modified slightly to work with the Keepkey library.

This also adds an automated test for the KeepKey using the KeepKey simulator.