### PR TITLE
Ensure that a bogus signature will always be created for ignored inputs on Trezor

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -131,6 +131,8 @@ class TrezorClient(HardwareWalletClient):
 
                 def ignore_input():
                     txinputtype.address_n = [0x80000000]
+                    txinputtype.multisig = None
+                    txinputtype.script_type = proto.InputScriptType.SPENDWITNESS
                     inputs.append(txinputtype)
                     to_ignore.append(input_num)
 

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -321,8 +321,7 @@ class TestSignTx(DeviceTestCase):
             psbt = self.wrpc.walletcreatefundedpsbt([], [{self.wpk_rpc.getnewaddress():(i+1)*send_amount}], 0, {'includeWatching': True, 'subtractFeeFromOutputs': [0]}, True)
 
             # Sign with unknown inputs in two steps
-            if self.type is not 'trezor': # https://github.com/achow101/HWI/issues/100
-                self._generate_and_finalize(True, psbt)
+            self._generate_and_finalize(True, psbt)
             # Sign all inputs all at once
             final_tx = self._generate_and_finalize(False, psbt)
 


### PR DESCRIPTION
Fixes the issue where multisig inputs not belonging to the trezorwould cause an error. Also re-enables that test for the trezor

Fixes #100