### PR TITLE
Update digital bitbox encryption scheme for firmware v5 and bug fixes

### DIFF
--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -187,14 +187,14 @@ def ser_sig_der(r, s):
     # Make r and s as short as possible
     ri = 0
     for b in r:
-        if b == "\x00":
+        if b == 0:
             ri += 1
         else:
             break
     r = r[ri:]
     si = 0
     for b in s:
-        if b == "\x00":
+        if b == 0:
             si += 1
         else:
             break;


### PR DESCRIPTION
Firmvware v5.0.0 changed how messages are encrypted and authenticated, so update the encryption methodolgy to handle that.

The changes come from https://github.com/digitalbitbox/mcu/blob/master/py/dbb_utils.py with some minor changes to accommodate older firmware versions.

A bug in DER serialization which is only used by the bitbox is also fixed here.