### PR TITLE
More verbose test output indicating which tests for which devices pass tests

### DIFF
--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -54,5 +54,5 @@ if args.digitalbitbox:
         print('Cannot run Digital Bitbox test without --password set')
 if not args.no_keepkey:
     suite.addTest(keepkey_test_suite(args.keepkey, rpc, userpass))
-result = unittest.TextTestRunner(stream=sys.stdout).run(suite)
+result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
 sys.exit(not result.wasSuccessful())

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -63,4 +63,4 @@ if __name__ == '__main__':
     rpc, userpass = start_bitcoind(args.bitcoind)
 
     suite = coldcard_test_suite(args.simulator, rpc, userpass)
-    unittest.TextTestRunner().run(suite)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -75,6 +75,12 @@ class DeviceTestCase(unittest.TestCase):
             suite.addTest(testclass(rpc, rpc_userpass, type, path, fingerprint, master_xpub, password, emulator, name))
         return suite
 
+    def __str__(self):
+        return '{}: {}'.format(self.type, super().__str__())
+
+    def __repr__(self):
+        return '{}: {}'.format(self.type, super().__repr__())
+
 class TestDeviceConnect(DeviceTestCase):
     def setUp(self):
         self.emulator.start()

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -39,4 +39,4 @@ if __name__ == '__main__':
     rpc, userpass = start_bitcoind(args.bitcoind)
 
     suite = digitalbitbox_test_suite(rpc, userpass, args.password)
-    unittest.TextTestRunner().run(suite)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -129,4 +129,4 @@ if __name__ == '__main__':
     rpc, userpass = start_bitcoind(args.bitcoind)
 
     suite = keepkey_test_suite(args.emulator, rpc, userpass)
-    unittest.TextTestRunner(stream=sys.stdout).run(suite)
+    unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -73,6 +73,12 @@ class KeepkeyTestCase(unittest.TestCase):
             suite.addTest(testclass(emulator, name))
         return suite
 
+    def __str__(self):
+        return 'keepkey: {}'.format(super().__str__())
+
+    def __repr__(self):
+        return 'keepkey: {}'.format(super().__repr__())
+
 # Keepkey specific getxpub test because this requires device specific thing to set xprvs
 class TestKeepkeyGetxpub(KeepkeyTestCase):
     def setUp(self):

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -45,4 +45,4 @@ if __name__ == '__main__':
     rpc, userpass = start_bitcoind(args.bitcoind)
 
     suite = ledger_test_suite(rpc, userpass)
-    unittest.TextTestRunner().run(suite)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -70,6 +70,12 @@ class TrezorTestCase(unittest.TestCase):
             suite.addTest(testclass(emulator, name))
         return suite
 
+    def __str__(self):
+        return 'trezor: {}'.format(super().__str__())
+
+    def __repr__(self):
+        return 'trezor: {}'.format(super().__repr__())
+
 # Trezor specific getxpub test because this requires device specific thing to set xprvs
 class TestTrezorGetxpub(TrezorTestCase):
     def setUp(self):

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -126,4 +126,4 @@ if __name__ == '__main__':
     rpc, userpass = start_bitcoind(args.bitcoind)
 
     suite = trezor_test_suite(args.emulator, rpc, userpass)
-    unittest.TextTestRunner(stream=sys.stdout).run(suite)
+    unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)


### PR DESCRIPTION
Increases the verbosity level of the test runner to 2 which outputs the `str()` representation of each test case. This includes the test name by default. This has been modified to also print out the device types for the tests in `test_devices.py`. This will allow us to be able to see what tests each device is passing so debugging is easier.