### PR TITLE
Ledger firmware doesn't support mixed input types during signing pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Please also see [docs](docs/) for additional information about each device.
 | Aribtrary redeemScript Inputs | Yes | N/A | Yes | N/A | N/A |
 | Arbitrary witnessScript Inputs | Yes | N/A | Yes | N/A | N/A |
 | Non-wallet inputs | Yes | Yes | Yes | Yes | Yes |
-| Mixed Segwit and Non-Segwit Inputs | No | Yes | Yes | Yes | Yes |
+| Mixed Segwit and Non-Segwit Inputs | N/A | Yes | Yes | Yes | Yes |
 | Display on device screen | Yes | Yes | N/A | Yes | Yes |
 
 ## Using with Bitcoin Core


### PR DESCRIPTION
You can theoretically sign but requires that all inputs are given as non-segwit UTXO, so not compliant with BIP174.