### PR TITLE
Move prompts to stderr

### DIFF
--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -11,6 +11,7 @@ import base64
 import json
 import hid
 import io
+import sys
 import time
 
 CC_SIMULATOR_SOCK = '/tmp/ckcc-simulator.sock'
@@ -77,7 +78,7 @@ class ColdcardClient(HardwareWalletClient):
         if self.device.is_simulator:
             self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
 
-        print("Waiting for OK on the Coldcard...")
+        print("Waiting for OK on the Coldcard...", file=sys.stderr)
 
         while 1:
             time.sleep(0.250)

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -11,6 +11,7 @@ import os
 import binascii
 import logging
 import socket
+import sys
 import time
 
 from ..hwwclient import HardwareWalletClient, NoPasswordError, UnavailableActionError
@@ -358,7 +359,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         logging.debug(reply)
         if 'error' in reply:
             return reply
-        print("Touch the device for 3 seconds to sign. Touch briefly to cancel")
+        print("Touch the device for 3 seconds to sign. Touch briefly to cancel", file=sys.stderr)
         reply = send_encrypt(to_send, self.password, self.device)
         logging.debug(reply)
         if 'error' in reply:
@@ -400,7 +401,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         logging.debug(reply)
         if 'error' in reply:
             return reply
-        print("Touch the device for 3 seconds to sign. Touch briefly to cancel")
+        print("Touch the device for 3 seconds to sign. Touch briefly to cancel", file=sys.stderr)
         reply = send_encrypt(to_send, self.password, self.device)
         logging.debug(reply)
         if 'error' in reply:


### PR DESCRIPTION
Instead of printing prompts to stdout, print them to stderr. When used on the command line, the prompts will be seen by the user. But using stderr means that external callers of the command can ignore that output and only use the actual output from stdout.

The Trezor and Keepkey prompts already go to stderr.