### PR TITLE
Provide PINs to Trezor and KeepKey via commands

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 from .commands import backup_device, displayaddress, enumerate, find_device, \
-    get_client, getmasterxpub, getxpub, getkeypool, restore_device, setup_device, \
+    get_client, getmasterxpub, getxpub, getkeypool, prompt_pin, restore_device, send_pin, setup_device, \
     signmessage, signtx, wipe_device, NO_DEVICE_PATH, DEVICE_CONN_ERROR, NO_PASSWORD, \
     UNKNWON_DEVICE_TYPE
 
@@ -43,6 +43,12 @@ def signtx_handler(args, client):
 
 def wipe_device_handler(args, client):
     return wipe_device(client)
+
+def prompt_pin_handler(args, client):
+    return prompt_pin(client)
+
+def send_pin_handler(args, client):
+    return send_pin(client, pin=args.pin)
 
 def process_commands(args):
     parser = argparse.ArgumentParser(description='Access and send commands to a hardware wallet device. Responses are in JSON format')
@@ -110,6 +116,13 @@ def process_commands(args):
     backup_parser.add_argument('--label', '-l', help='The name to give to the device', default='')
     backup_parser.add_argument('--backup_passphrase', '-b', help='The passphrase to use for the backup, if applicable', default='')
     backup_parser.set_defaults(func=backup_device_handler)
+
+    promptpin_parser = subparsers.add_parser('promptpin', help='Have the device prompt for your PIN')
+    promptpin_parser.set_defaults(func=prompt_pin_handler)
+
+    sendpin_parser = subparsers.add_parser('sendpin', help='Send the numeric positions for your PIN to the device')
+    sendpin_parser.add_argument('pin', help='The numeric positions of the PIN')
+    sendpin_parser.set_defaults(func=send_pin_handler)
 
     args = parser.parse_args(args)
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -8,7 +8,7 @@ import importlib
 from .serializations import PSBT, Base64ToHex, HexToBase64, hash160
 from .base58 import xpub_to_address, xpub_to_pub_hex, get_xpub_fingerprint_as_id, get_xpub_fingerprint_hex
 from os.path import dirname, basename, isfile
-from .hwwclient import NoPasswordError, UnavailableActionError, DeviceAlreadyInitError
+from .hwwclient import NoPasswordError, UnavailableActionError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError
 
 # Error codes
 NO_DEVICE_PATH = -1
@@ -21,6 +21,7 @@ BAD_ARGUMENT = -7
 NOT_IMPLEMENTED = -8
 UNAVAILABLE_ACTION = -9
 DEVICE_ALREADY_INIT = -10
+DEVICE_ALREADY_UNLOCKED = -11
 
 class UnknownDeviceError(Exception):
     def __init__(self,*args,**kwargs):
@@ -218,5 +219,19 @@ def backup_device(client, label='', backup_passphrase=''):
         return client.backup_device(label, backup_passphrase)
     except UnavailableActionError as e:
         return {'error': str(e), 'code': UNAVAILABLE_ACTION}
+    except ValueError as e:
+        return {'error': str(e), 'code': BAD_ARGUMENT}
+
+def prompt_pin(client):
+    try:
+        return client.prompt_pin()
+    except DeviceAlreadyUnlockedError as e:
+        return {'error': str(e), 'code': DEVICE_ALREADY_UNLOCKED}
+
+def send_pin(client, pin):
+    try:
+        return client.send_pin(pin)
+    except DeviceAlreadyUnlockedError as e:
+        return {'error': str(e), 'code': DEVICE_ALREADY_UNLOCKED}
     except ValueError as e:
         return {'error': str(e), 'code': BAD_ARGUMENT}

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -183,6 +183,14 @@ class ColdcardClient(HardwareWalletClient):
     def close(self):
         self.device.close()
 
+    # Prompt pin
+    def prompt_pin(self):
+        raise UnavailableActionError('The Coldcard does not need a PIN sent from the host')
+
+    # Send pin
+    def send_pin(self):
+        raise UnavailableActionError('The Coldcard does not need a PIN sent from the host')
+
 def enumerate(password=''):
     results = []
     for d in hid.enumerate(COINKITE_VID, CKCC_PID):

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -469,6 +469,14 @@ class DigitalbitboxClient(HardwareWalletClient):
     def close(self):
         self.device.close()
 
+    # Prompt pin
+    def prompt_pin(self):
+        raise UnavailableActionError('The Digtal Bitbox does not need a PIN sent from the host')
+
+    # Send pin
+    def send_pin(self):
+        raise UnavailableActionError('The Digital Bitbox does not need a PIN sent from the host')
+
 def enumerate(password=''):
     results = []
     devices = hid.enumerate(DBB_VENDOR_ID, DBB_DEVICE_ID)

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -268,6 +268,14 @@ class LedgerClient(HardwareWalletClient):
     def close(self):
         self.dongle.close()
 
+    # Prompt pin
+    def prompt_pin(self):
+        raise UnavailableActionError('The Ledger Nano S does not need a PIN sent from the host')
+
+    # Send pin
+    def send_pin(self):
+        raise UnavailableActionError('The Ledger Nano S does not need a PIN sent from the host')
+
 def enumerate(password=''):
     results = []
     for d in hid.enumerate(LEDGER_VENDOR_ID, LEDGER_DEVICE_ID):

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -54,6 +54,14 @@ class HardwareWalletClient(object):
         raise NotImplementedError('The HardwareWalletClient base class does not '
             'implement this method')
 
+    # Prompt pin
+    def prompt_pin(self):
+        raise NotImplementedError('The HardwareWalletClient base class does not implement this method')
+
+    # Send pin
+    def send_pin(self):
+        raise NotImplementedError('The HardwareWalletClient base class does not implement this method')
+
 class NoPasswordError(Exception):
     def __init__(self,*args,**kwargs):
         Exception.__init__(self,*args,**kwargs)
@@ -63,5 +71,13 @@ class UnavailableActionError(Exception):
         Exception.__init__(self,*args,**kwargs)
 
 class DeviceAlreadyInitError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+class DeviceNotReadyError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+class DeviceAlreadyUnlockedError(Exception):
     def __init__(self,*args,**kwargs):
         Exception.__init__(self,*args,**kwargs)


### PR DESCRIPTION
This PR introduces two new commands, `promptpin` and `sendpin`, which only work on Trezors and KeepKeys. `promptpin` triggers the device to display the prompt for entering the PIN. `sendpin` takes the scrambled PIN as an argument and sends it to the device. The device will then cache the pin if it is correct.

The way that the libraries setup the client classes prevents us from doing this. To work around that, I made subclasses of those client classes which do not do the initialization call that breaks this process. Instead, the initialization call will be done by each function individually if it needs it.

Closes #83