### PR TITLE
Use updated upstream things

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip3 install hidapi # HID API needed in general
 pip3 install trezor[hidapi] # Trezor One
 pip3 install btchip-python # Ledger Nano S
 pip3 install ecdsa # Needed for btchip-python but is not installed by it
-pip3 install git+git://github.com/keepkey/python-keepkey.git@43fe80ae2e54b274c7b8641ff409bce4ebe04914#egg=keepkey # KeepKey. The tags and pypi don't have the right version yet, so lock to a specific commit from their git repo
+pip3 install keepkey # KeepKey
 pip3 install ckcc-protocol[cli] # Coldcard
 pip3 install pyaes # For digitalbitbox
 ```

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,10 @@ setuptools.setup(
         'hidapi', # HID API needed in general
         'trezor>=0.11.0', # Trezor One
         'btchip-python', # Ledger Nano S
-        'keepkey==6.0.1', # KeepKey
+        'keepkey>=6.0.1', # KeepKey
         'ckcc-protocol[cli]', # Coldcard
         'pyaes',
         'ecdsa', # Needed for Ledger but their library does not install it
-    ],
-    dependency_links=[
-        'https://github.com/keepkey/python-keepkey/tarball/43fe80ae2e54b274c7b8641ff409bce4ebe04914#egg=keepkey-6.0.1' # The tags don't have the right version yet, so lock to a specific commit
     ],
     python_requires='>=3',
     classifiers=[

--- a/test/README.md
+++ b/test/README.md
@@ -112,7 +112,7 @@ build-essential git cmake
 Clone the repository:
 
 ```
-$ git clone https://github.com/achow101/mcu -b simulator
+$ git clone https://github.com/digitalbitbox/mcu
 ```
 
 Build the simulator:

--- a/test/README.md
+++ b/test/README.md
@@ -124,6 +124,40 @@ $ cmake .. -DBUILD_TYPE=simulator
 $ make
 ```
 
+## KeepKey emulator
+
+### Dependencies
+
+In order to build the KeepKey emulator, the following packages will need to be installed:
+
+```
+build-essential git python2 python2-pip
+```
+
+The python packages can be installed with
+
+```
+pip install protobuf
+```
+
+### Building
+
+Clone the repository and dependencies:
+
+```
+$ git clone https://github.com/keepkey/keepkey-firmware.git
+$ cd keepkey-firmware
+$ git clone https://github.com/nanopb/nanopb.git -b nanopb-0.2.9.2
+```
+
+Build the emulator:
+
+```
+$ export PATH=$PATH:`pwd`/nanopb/generator
+$ cmake -C cmake/caches/emulator.cmake . -DNANOPB_DIR=nanopb/ -DKK_HAVE_STRLCAT=OFF -DKK_HAVE_STRLCPY=OFF
+$ make kkemu
+```
+
 ## Bitcoin Core
 
 In order to build `bitcoind`, see [Bitcoin Core's build documentation](https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#linux-distribution-specific-instructions) to get all of the dependencies installed and for instructions on how to build.

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -79,7 +79,7 @@ cd ../..
 # Clone digital bitbox firmware if it doesn't exist, or update it if it does
 dbb_setup_needed=false
 if [ ! -d "mcu" ]; then
-    git clone --recursive https://github.com/achow101/mcu.git -b simulator
+    git clone --recursive https://github.com/digitalbitbox/mcu.git
     cd mcu
     dbb_setup_needed=true
 else


### PR DESCRIPTION
Keepkey has updated their PyPi to have their latest library version, so switch things to using that instead of using a specific commit from their repo.

The Digital Bitbox simulator was merged into the upstream repo so use that instead of my own branch for it.

Also added documentation for building the Keepkey emulator.